### PR TITLE
去除跳转到 chrome 插件商店

### DIFF
--- a/web/static/har/editor.coffee
+++ b/web/static/har/editor.coffee
@@ -40,7 +40,7 @@ define (require, exports, module) ->
 
     if $('body').attr('get-cookie') is undefined
       alert('尚未安装GetCookie插件，请安装插件或手动获取！')
-      $this.attr('href', 'https://chrome.google.com/webstore/detail/cookies-get-assistant/ljjpkibacifkfolehlgaolibbnlapkme').attr('target', '_blank')
+      # $this.attr('href', 'https://chrome.google.com/webstore/detail/cookies-get-assistant/ljjpkibacifkfolehlgaolibbnlapkme').attr('target', '_blank')
       return
   )
   window.addEventListener("message", (ev) ->

--- a/web/static/har/editor.js
+++ b/web/static/har/editor.js
@@ -37,7 +37,7 @@
       cookie_input = angular.element($this.parent().find('input'));
       if ($('body').attr('get-cookie') === void 0) {
         alert('尚未安装GetCookie插件，请安装插件或手动获取！');
-        $this.attr('href', 'https://chrome.google.com/webstore/detail/cookies-get-assistant/ljjpkibacifkfolehlgaolibbnlapkme').attr('target', '_blank');
+        // $this.attr('href', 'https://chrome.google.com/webstore/detail/cookies-get-assistant/ljjpkibacifkfolehlgaolibbnlapkme').attr('target', '_blank');
       }
     });
     window.addEventListener("message", function(ev) {

--- a/web/tpl/utils.html
+++ b/web/tpl/utils.html
@@ -151,7 +151,7 @@ $(function() {
 
     if ($('body').attr('get-cookie') === undefined) {
       alert('尚未安装GetCookie插件，请安装插件或手动获取！');
-      $this.attr('href', 'https://chrome.google.com/webstore/detail/cookies-get-assistant/ljjpkibacifkfolehlgaolibbnlapkme').attr('target', '_blank');
+      // $this.attr('href', 'https://chrome.google.com/webstore/detail/cookies-get-assistant/ljjpkibacifkfolehlgaolibbnlapkme').attr('target', '_blank');
       return;
     }
   });


### PR DESCRIPTION
由于 GetCookies 这个插件已经下架，再跳转过去也是一个错误界面，不如将它注释掉比较好。