### PR TITLE
修复错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ docker部署命令：``` docker run -d --name qiandao -p 12345:80 -v $(pwd)/qian
 
 数据库恢复指令：```docker cp database.db 容器名:/usr/src/app/config/ ```
 
-docker配置邮箱(强制使用SSL)：```docker run -d --name qiandao -p 12345:80 -v $(pwd)/qiandao/config:/usr/src/app/config --env MAIL_SMTP=STMP服务器 --env MAIL_PORT=邮箱服务器端口 --env MAIL_USER=用户名 --env MAIL_PASSWORD=密码 --env MAIL_PASSWORD=密码 --env DOMAIN=域名 asdaragon/qiandao ```
+docker配置邮箱(强制使用SSL)：```docker run -d --name qiandao -p 12345:80 -v $(pwd)/qiandao/config:/usr/src/app/config --env MAIL_SMTP=STMP服务器 --env MAIL_PORT=邮箱服务器端口 --env MAIL_USER=用户名 --env MAIL_PASSWORD=密码 --env ENABLE_HTTPS=True --env DOMAIN=域名 asdaragon/qiandao ```
 
 docker 使用MySQL：```docker run -d --name qiandao -p 12345:80 -v $(pwd)/qiandao/config:/usr/src/app/config --ENV DB_TYPE=mysql --ENV JAWSDB_MARIA_URL=mysql://用户名:密码@链接/数据库名 asdaragon/qiandao ```
 


### PR DESCRIPTION
docker配置邮箱(强制使用SSL)环境变量出现了两个PASSWORD，没有启用SSL