### PR TITLE
Python 3.10 兼容

### DIFF
--- a/libs/cookie_utils.py
+++ b/libs/cookie_utils.py
@@ -6,7 +6,10 @@
 # Created on 2012-09-12 22:39:57
 # form requests&tornado
 
-from collections import MutableMapping as DictMixin
+try:
+    from collections import MutableMapping as DictMixin
+except ImportError:
+    from collections.abc import MutableMapping as DictMixin
 import http.cookiejar as cookielib
 from urllib.parse import urlparse
 from tornado import httpclient, httputil


### PR DESCRIPTION
ImportError: cannot import name 'MutableMapping' from 'collections' (/usr/lib/python3.10/collections/__init__.py)
https://stackoverflow.com/questions/69381312/in-vs-code-importerror-cannot-import-name-mapping-from-collections/69727802#69727802