### PR TITLE
增加 HAR 测试时的代理选项：`env.variables._proxy`

### DIFF
--- a/libs/json_typing.py
+++ b/libs/json_typing.py
@@ -1,5 +1,5 @@
 import typing
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 
 class Env(TypedDict):

--- a/libs/json_typing.py
+++ b/libs/json_typing.py
@@ -1,0 +1,62 @@
+import typing
+from typing_extensions import TypedDict
+
+
+class Env(TypedDict):
+    variables: typing.Dict[str, str]
+    "用户设置 Task 变量"
+    session: typing.List  # TODO：暂时还没看到list中是什么东西
+
+
+class _NameVlaue(TypedDict):
+    name: str
+    value: str
+
+
+Cookie = _NameVlaue
+Header = _NameVlaue
+
+
+class Request(TypedDict):
+    url: str
+    method: typing.Literal[
+        "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"
+    ]  # | str
+    headers: typing.List[Header]
+    cookies: typing.List[Cookie]
+
+
+ExtractVariable = TypedDict(  # 内含 from 关键字，所以用这个方式声明
+    "ExtractVariable",
+    {
+        "name": str,
+        "re": str,
+        "from": typing.Literal["content", "status", "header", "header-location"],
+    },
+)
+FailedAssert = TypedDict(
+    "FailedAssert",
+    {
+        "re": str,
+        "from": typing.Literal["content", "status", "header", "header-location"],
+    },
+)
+SuccessAssert = TypedDict(
+    "SuccessAssert",
+    {
+        "re": str,
+        "from": typing.Literal["content", "status", "header", "header-location"],
+    },
+)
+
+
+class Rule(TypedDict):
+    extract_variables: typing.List[ExtractVariable]
+    failed_asserts: typing.List[FailedAssert]
+    success_asserts: typing.List[SuccessAssert]
+
+
+class HARTest(TypedDict):  # 可能也被用到了其它地方，暂时命名为 HARTest
+    env: Env
+    request: Request
+    rule: Rule

--- a/web/handlers/base.py
+++ b/web/handlers/base.py
@@ -13,7 +13,7 @@ from tornado.web import HTTPError
 
 import config
 from db import DB
-from libs import utils
+from libs import utils, fetcher
 from libs.log import Log
 
 logger_Web_Handler = Log('qiandao.Web.Handler').getlogger()
@@ -23,6 +23,7 @@ __ALL__ = ['HTTPError', 'BaseHandler', 'BaseWebSocket', 'BaseUIModule', 'logger_
 class BaseHandler(tornado.web.RequestHandler):
     application_export = set(('db', 'fetcher'))
     db:DB
+    fetcher: fetcher.Fetcher
     # db = DB()
     def __getattr__(self, key):
         if key in self.application_export:

--- a/web/handlers/har.py
+++ b/web/handlers/har.py
@@ -119,10 +119,10 @@ class HARTest(BaseHandler):
                     'username': _proxy['username'],
                     'password': _proxy['password']
                 }
+                ret = await self.fetcher.fetch(data, proxy=proxy)
             else:
-                proxy = {}
+                await self.fetcher.fetch(data)
 
-            ret = await self.fetcher.fetch(data, proxy=proxy)
 
             result = {
                     'success': ret['success'],


### PR DESCRIPTION
close #353

- 增加了 `HARTest` 的代理选项
- 初步创建 JSON Typing

---

现在可以直接在测试时创建变量 `_proxy` 来设置代理了（虽然觉得 `__proxy__` 这样命名能和 `__log__` 保持一致，但是 `task` 部分已经使用 `_proxy` 这个名字了）


另外创建了 `JSON` 的 Type hitting： `libs/json_typing.py`，这样编辑器就可以为 `JSON` 提供自动补全和检查，能有效减少在这方面的 typo
目前只创建了 `HARTest` 会用到的部分