### PR TITLE
Fix: Cross origin websockets not allowed

### DIFF
--- a/web/handlers/subscribe.py
+++ b/web/handlers/subscribe.py
@@ -12,13 +12,13 @@ import random
 import time
 import traceback
 from typing import Any, Dict
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import aiohttp
 from tornado import httputil
 from tornado.web import Application
 
-from config import proxies
+from config import proxies, domain
 
 from .base import *
 
@@ -56,6 +56,10 @@ class SubscribeUpdatingHandler(BaseWebSocketHandler):
     users:Dict[int, BaseWebSocketHandler] = {}
     updating = False
     updating_start_time = 0
+
+    def check_origin(self, origin):
+        parsed_origin = urlparse(origin)                              
+        return parsed_origin.netloc.endswith(domain)
 
     async def update(self, userid):
         SubscribeUpdatingHandler.updating = True


### PR DESCRIPTION
## 环境:

Docker-compose + nginx (https) 反代

<details>
<summary>配置信息</summary>

> Docker 环境变量配置:

```
      - DOMAIN=qiandao.example.com:8443
      - REDISCLOUD_URL=redis://redis:6379
      - PBKDF2_ITERATIONS=400
      - AES_KEY=Xx****xX
      - COOKIE_SECRET=Xx****xX
```

> Nginx 配置:

```
    location / {
        proxy_http_version 1.1;
        proxy_connect_timeout 60s;
        proxy_read_timeout 5400s;
        proxy_send_timeout 5400s;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "Upgrade";
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_pass http://127.0.0.1:8923/;
    }
```
</details>

## 问题重现步骤：

使用域名访问公共模板库，点击重建缓存，可在开发者工具中看到 `/subscribe/1/updating/` 访问失败，后端日志状态码显示403，开启Debug后，可看到具体的报错为：

`tornado.general websocket:267] Cross origin websockets not allowed`

## 解决：

添加 `check_origin`  函数配合配置项 `domain`  进行跨域验证以解决该问题
