### PR TITLE
更新加速镜像

### DIFF
--- a/config.py
+++ b/config.py
@@ -144,10 +144,10 @@ class websocket:
 
 
 # 订阅加速方式或地址, 用于加速公共模板更新, 仅适用于 GitHub.
-# 可选 jsdelivr_cdn/jsdelivr_fastly/ghproxy/fastgit/自定义地址, 默认为: jsdelivr_cdn.
-# 自定义地址示例为: https://ghproxy.com/https://raw.githubusercontent.com/ 或 https://raw.fastgit.org/
+# 可选 jsdelivr_cdn/jsdelivr_fastly/ghproxy/fastgit/自定义地址, 默认为: ghproxy
+# 自定义地址示例为: https://ghp.ci/https://raw.githubusercontent.com/ 或 https://raw.fastgit.org/
 # 以直接替换 https://raw.githubusercontent.com/ 源文件地址.
-subscribe_accelerate_url = os.getenv('SUBSCRIBE_ACCELERATE_URL', 'jsdelivr_cdn')
+subscribe_accelerate_url = os.getenv('SUBSCRIBE_ACCELERATE_URL', 'ghproxy')
 
 # 全局代理域名列表相关设置
 ## proxies为全局代理域名列表, 默认为空[], 表示不启用全局代理;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       # - WS_MAX_MESSAGE_SIZE=10485760
       # - WS_MAX_QUEUE_SIZE=100
       # - WS_MAX_CONNECTIONS_SUBSCRIBE=30
-      # - SUBSCRIBE_ACCELERATE_URL=jsdelivr_cdn
+      # - SUBSCRIBE_ACCELERATE_URL=ghproxy
       # - PROXIES=
       # - PROXY_DIRECT_MODE=regexp
       # - PROXY_DIRECT=(?xi)\A([a-z][a-z0-9+\-.]*://)?(0(.0){3}|127(.0){2}.1|localhost|\[::([\d]+)?\])(:[0-9]+)?

--- a/web/docs/guide/deployment.md
+++ b/web/docs/guide/deployment.md
@@ -186,6 +186,6 @@ python ./chrole.py your@email.address admin
 |WS_MAX_MESSAGE_SIZE|No|10485760|WebSocket maximum message size, the default is 10485760 bytes|
 |WS_MAX_QUEUE_SIZE|No|100|WebSocket maximum queue size, the default is 100|
 |WS_MAX_CONNECTIONS_SUBSCRIBE|No|30|WebSocket subscribe page maximum number of connections, the default is 30|
-|SUBSCRIBE_ACCELERATE_URL|No|jsdelivr_cdn|Subscribe page acceleration URL, the default is jsdelivr_cdn, <br>[See configuration for details](https://github.com/qd-today/qd/blob/master/config.py)...|
+|SUBSCRIBE_ACCELERATE_URL|No|ghproxy|Subscribe page acceleration URL, the default is ghproxy, <br>[See configuration for details](https://github.com/qd-today/qd/blob/master/config.py)...|
 
 > For details, please refer to [config.py](https://github.com/qd-today/qd/blob/master/config.py)

--- a/web/handlers/subscribe.py
+++ b/web/handlers/subscribe.py
@@ -90,7 +90,7 @@ class SubscribeUpdatingHandler(BaseWebSocketHandler):
                             elif config.subscribe_accelerate_url == 'jsdelivr_fastly':
                                 url = f"{repo['repourl'].replace('https://github.com/', 'https://fastly.jsdelivr.net/gh/')}@{repo['repobranch']}"
                             elif config.subscribe_accelerate_url == 'ghproxy':
-                                url = f"{repo['repourl'].replace('https://github.com/', 'https://ghproxy.com/https://raw.githubusercontent.com/')}/{repo['repobranch']}"
+                                url = f"{repo['repourl'].replace('https://github.com/', 'https://ghp.ci/https://raw.githubusercontent.com/')}/{repo['repobranch']}"
                             elif config.subscribe_accelerate_url == 'fastgit':
                                 url = f"{repo['repourl'].replace('https://github.com/', 'https://raw.fastgit.org/')}/{repo['repobranch']}"
                             else:


### PR DESCRIPTION
jsdelivr_cdn
ghproxy.com都被墙了
许多人搞不定，跟换默认cnd为ghproxy的新域名：https://ghp.ci/