### PR TITLE
更新自建加速镜像

### DIFF
--- a/config.py
+++ b/config.py
@@ -144,10 +144,10 @@ class websocket:
 
 
 # 订阅加速方式或地址, 用于加速公共模板更新, 仅适用于 GitHub.
-# 可选 jsdelivr_cdn/jsdelivr_fastly/ghproxy/fastgit/自定义地址, 默认为: ghproxy
-# 自定义地址示例为: https://ghp.ci/https://raw.githubusercontent.com/ 或 https://raw.fastgit.org/
+# 可选 jsdelivr_cdn/jsdelivr_fastly/ghproxy/qd-ph/自定义地址, 默认为: qd-ph
+# 自定义地址示例为: https://qd-gh.crossg.us.kg/https://raw.githubusercontent.com/
 # 以直接替换 https://raw.githubusercontent.com/ 源文件地址.
-subscribe_accelerate_url = os.getenv('SUBSCRIBE_ACCELERATE_URL', 'ghproxy')
+subscribe_accelerate_url = os.getenv('SUBSCRIBE_ACCELERATE_URL', 'qd-ph')
 
 # 全局代理域名列表相关设置
 ## proxies为全局代理域名列表, 默认为空[], 表示不启用全局代理;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       # - WS_MAX_MESSAGE_SIZE=10485760
       # - WS_MAX_QUEUE_SIZE=100
       # - WS_MAX_CONNECTIONS_SUBSCRIBE=30
-      # - SUBSCRIBE_ACCELERATE_URL=ghproxy
+      # - SUBSCRIBE_ACCELERATE_URL=qd-ph
       # - PROXIES=
       # - PROXY_DIRECT_MODE=regexp
       # - PROXY_DIRECT=(?xi)\A([a-z][a-z0-9+\-.]*://)?(0(.0){3}|127(.0){2}.1|localhost|\[::([\d]+)?\])(:[0-9]+)?

--- a/web/docs/guide/deployment.md
+++ b/web/docs/guide/deployment.md
@@ -186,6 +186,6 @@ python ./chrole.py your@email.address admin
 |WS_MAX_MESSAGE_SIZE|No|10485760|WebSocket maximum message size, the default is 10485760 bytes|
 |WS_MAX_QUEUE_SIZE|No|100|WebSocket maximum queue size, the default is 100|
 |WS_MAX_CONNECTIONS_SUBSCRIBE|No|30|WebSocket subscribe page maximum number of connections, the default is 30|
-|SUBSCRIBE_ACCELERATE_URL|No|ghproxy|Subscribe page acceleration URL, the default is ghproxy, <br>[See configuration for details](https://github.com/qd-today/qd/blob/master/config.py)...|
+|SUBSCRIBE_ACCELERATE_URL|No|qd-ph|Subscribe page acceleration URL, the default is qd-ph, <br>[See configuration for details](https://github.com/qd-today/qd/blob/master/config.py)...|
 
 > For details, please refer to [config.py](https://github.com/qd-today/qd/blob/master/config.py)

--- a/web/docs/zh_CN/guide/faq.md
+++ b/web/docs/zh_CN/guide/faq.md
@@ -143,3 +143,14 @@ QD 使用 `pycurl` 模块来发送 HTTP Proxy 请求。如果没有安装 `pycur
 >     }
 > }
 > ```
+
+## 错误代码：4006
+> 提示错误信息为："更新失败，原因：Cannot connect to host xxx.xxx:443ssl:False"
+
+报错原因：github/或github加速源无法连接。
+
+解决方法1：挂代理
+
+解决方法2：更换github加速源
+容器的环境变量中增加/修改`SUBSCRIBE_ACCELERATE_URL=https://xxx.xxx/https://raw.githubusercontent.com/`
+`https://xxx.xxx/`替换为可用的加速源，找不到加速源的可以参考 https://ghproxy.link/中发布的加速源

--- a/web/handlers/subscribe.py
+++ b/web/handlers/subscribe.py
@@ -90,9 +90,9 @@ class SubscribeUpdatingHandler(BaseWebSocketHandler):
                             elif config.subscribe_accelerate_url == 'jsdelivr_fastly':
                                 url = f"{repo['repourl'].replace('https://github.com/', 'https://fastly.jsdelivr.net/gh/')}@{repo['repobranch']}"
                             elif config.subscribe_accelerate_url == 'ghproxy':
-                                url = f"{repo['repourl'].replace('https://github.com/', 'https://ghp.ci/https://raw.githubusercontent.com/')}/{repo['repobranch']}"
-                            elif config.subscribe_accelerate_url == 'fastgit':
-                                url = f"{repo['repourl'].replace('https://github.com/', 'https://raw.fastgit.org/')}/{repo['repobranch']}"
+                                url = f"{repo['repourl'].replace('https://github.com/', 'https://ghfast.top/https://raw.githubusercontent.com/')}/{repo['repobranch']}"
+                            elif config.subscribe_accelerate_url == 'qd-ph':
+                                url = f"{repo['repourl'].replace('https://github.com/', 'https://qd-gh.crossg.us.kg/https://raw.githubusercontent.com/')}/{repo['repobranch']}"
                             else:
                                 if config.subscribe_accelerate_url.endswith('/'):
                                     url = f"{repo['repourl'].replace('https://github.com/', config.subscribe_accelerate_url)}/{repo['repobranch']}"


### PR DESCRIPTION
自带的几个加速源全部失效了，ghproxy网址也一直被墙、一直在变。
根据[https://github.com/hunshcn/gh-proxy](https://github.com/hunshcn/gh-proxy) 通过cf自建了了一个github加速源，设置了白名单只能加速"qd-today"和群友的“wjf0214/qd-templates”。免费版每天有 10 万次免费请求，并且有每分钟1000次请求的限制，应该够用