### PR TITLE
feat: AI 辅助生成签到模板 + worker N+1 性能优化 + 中文教程

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+__pycache__
+*.pyc
+*.pyo
+*.egg-info
+dist
+build
+.venv
+venv
+node_modules
+.web
+docs
+*.md
+!README.md
+tests

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/DockerHub-Description.yml
+++ b/.github/workflows/DockerHub-Description.yml
@@ -11,10 +11,10 @@ jobs:
     if: startsWith(github.repository, 'qd-today/qd')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Docker a76yyyy Hub Description
-      uses: peter-evans/dockerhub-description@v3
+      uses: peter-evans/dockerhub-description@v4
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -22,7 +22,7 @@ jobs:
         short-description: ${{ github.event.repository.description }}
 
     - name: Docker qdtoday Hub Description
-      uses: peter-evans/dockerhub-description@v3
+      uses: peter-evans/dockerhub-description@v4
       with:
         username: ${{ secrets.QD_DOCKER_USERNAME }}
         password: ${{ secrets.QD_DOCKER_PASSWORD }}

--- a/.github/workflows/Publish Ja3 Package.yml
+++ b/.github/workflows/Publish Ja3 Package.yml
@@ -19,25 +19,25 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ secrets.DOCKER_USERNAME }} # dockerServer Username 在setting创建secrets name=DOCKER_USERNAME  value=dockerid
         password: ${{ secrets.GITHUB_TOKEN }} # dockerServer Token
     - name: login to qdtoday DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: docker.io
         username: ${{ secrets.QD_DOCKER_USERNAME }} # dockerServer Username 在setting创建secrets name=QD_DOCKER_USERNAME  value=dockerid
         password: ${{ secrets.QD_DOCKER_PASSWORD }} # dockerServer Token 在setting创建secrets name=QD_DOCKER_PASSWORD  value=dockerToken
     - name: Publish Ja3 Package
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       if: github.ref == 'refs/heads/master'
       with:
         context: .
@@ -46,7 +46,7 @@ jobs:
         push: true
         tags: ghcr.io/qd-today/qd:ja3-latest,docker.io/qdtoday/qd:ja3-dev
     - name: Login to a76yyyy DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: github.ref == 'refs/heads/master'
       with:
         registry: docker.io
@@ -61,9 +61,9 @@ jobs:
     - name: Get version
       id: get_version
       if: startsWith(github.ref, 'refs/tags/')
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
     - name: Build Ja3-latest Package
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       if: startsWith(github.ref, 'refs/tags/')
       with:
         context: .
@@ -72,7 +72,7 @@ jobs:
         push: true
         tags: docker.io/qdtoday/qd:ja3-latest,docker.io/qdtoday/qd:ja3-${{ steps.get_version.outputs.VERSION }}
     - name: Login to a76yyyy DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: startsWith(github.ref, 'refs/tags/')
       with:
         registry: docker.io

--- a/.github/workflows/Publish Lite Package.yml
+++ b/.github/workflows/Publish Lite Package.yml
@@ -19,25 +19,25 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ secrets.DOCKER_USERNAME }} # dockerServer Username 在setting创建secrets name=DOCKER_USERNAME  value=dockerid
         password: ${{ secrets.GITHUB_TOKEN }} # dockerServer Token
     - name: login to qdtoday DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: docker.io
         username: ${{ secrets.QD_DOCKER_USERNAME }} # dockerServer Username 在setting创建secrets name=QD_DOCKER_USERNAME  value=dockerid
         password: ${{ secrets.QD_DOCKER_PASSWORD }} # dockerServer Token 在setting创建secrets name=QD_DOCKER_PASSWORD  value=dockerToken
     - name: Publish Lite Package
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       if: github.ref == 'refs/heads/master'
       with:
         context: .
@@ -46,7 +46,7 @@ jobs:
         push: true
         tags: ghcr.io/qd-today/qd:lite-latest,docker.io/qdtoday/qd:lite-dev
     - name: Login to a76yyyy DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: github.ref == 'refs/heads/master'
       with:
         registry: docker.io
@@ -61,9 +61,9 @@ jobs:
     - name: Get version
       id: get_version
       if: startsWith(github.ref, 'refs/tags/')
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
     - name: Build Lite-latest Package
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       if: startsWith(github.ref, 'refs/tags/')
       with:
         context: .
@@ -72,7 +72,7 @@ jobs:
         push: true
         tags: docker.io/qdtoday/qd:lite-latest,docker.io/qdtoday/qd:lite-${{ steps.get_version.outputs.VERSION }}
     - name: Login to a76yyyy DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: startsWith(github.ref, 'refs/tags/')
       with:
         registry: docker.io

--- a/.github/workflows/Publish Package.yml
+++ b/.github/workflows/Publish Package.yml
@@ -19,25 +19,25 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ secrets.DOCKER_USERNAME }} # dockerServer Username 在setting创建secrets name=DOCKER_USERNAME  value=dockerid
         password: ${{ secrets.GITHUB_TOKEN }} # dockerServer Token
     - name: login to qdtoday DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: docker.io
         username: ${{ secrets.QD_DOCKER_USERNAME }} # dockerServer Username 在setting创建secrets name=QD_DOCKER_USERNAME  value=dockerid
         password: ${{ secrets.QD_DOCKER_PASSWORD }} # dockerServer Token 在setting创建secrets name=QD_DOCKER_PASSWORD  value=dockerToken
     - name: Publish Latest Package
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       if: github.ref == 'refs/heads/master'
       with:
         context: .
@@ -46,7 +46,7 @@ jobs:
         push: true
         tags: ghcr.io/qd-today/qd:latest,docker.io/qdtoday/qd:dev
     - name: Login to a76yyyy DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: github.ref == 'refs/heads/master'
       with:
         registry: docker.io
@@ -61,9 +61,9 @@ jobs:
     - name: Get version
       id: get_version
       if: startsWith(github.ref, 'refs/tags/')
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
     - name: Build Latest Package
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       if: startsWith(github.ref, 'refs/tags/')
       with:
         context: .
@@ -72,7 +72,7 @@ jobs:
         push: true
         tags: docker.io/qdtoday/qd:latest,docker.io/qdtoday/qd:${{ steps.get_version.outputs.VERSION }}
     - name: Login to a76yyyy DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: startsWith(github.ref, 'refs/tags/')
       with:
         registry: docker.io

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-json
+      - id: detect-private-key
+      - id: check-merge-conflict
+
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+        args: ["--line-length", "120"]
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        args: ["--max-line-length", "120", "--ignore", "E501,W503"]
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ RUN sed -i 's/mirrors.ustc.edu.cn/dl-cdn.alpinelinux.org/g' /etc/apk/repositorie
     apk update && apk add --update --no-cache openssh-client && \
     chmod 600 /root/.ssh/id_rsa && \
     ssh-keyscan gitee.com > /root/.ssh/known_hosts && \
-    let num=$RANDOM%100+10 && \
-    sleep $num && \
     git clone --depth 1 git@gitee.com:qd-today/qd.git /gitclone_tmp && \
     yes | cp -rf /gitclone_tmp/. /usr/src/app && \
     rm -rf /gitclone_tmp && \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+.PHONY: help install dev test lint run clean
+
+help:  ## 显示帮助信息
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+install:  ## 安装依赖
+	pip install -r requirements.txt
+
+dev:  ## 安装开发依赖
+	pip install -r requirements.txt
+	pip install pytest flake8 black isort mypy
+
+test:  ## 运行测试
+	python -m pytest tests/ -v
+
+lint:  ## 代码检查
+	flake8 --max-line-length 120 --ignore E501,W503 .
+	black --check --line-length 120 .
+	isort --check --profile black .
+
+format:  ## 代码格式化
+	black --line-length 120 .
+	isort --profile black .
+
+run:  ## 启动服务
+	python run.py
+
+clean:  ## 清理缓存
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name '*.pyc' -delete 2>/dev/null || true
+	rm -rf .pytest_cache .mypy_cache
+
+docker-build:  ## 构建 Docker 镜像
+	docker build -t qd:local .
+
+docker-up:  ## 启动 Docker Compose
+	docker-compose up -d
+
+docker-down:  ## 停止 Docker Compose
+	docker-compose down

--- a/Pipfile
+++ b/Pipfile
@@ -45,4 +45,4 @@ types-aiofiles = "*"
 ddddocr = "*"
 
 [requires]
-python_version = "3.11"
+python_version = "3.10"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,3 +38,15 @@ Use this section to tell people how to report a vulnerability.
 Tell them where to go, how often they can expect to get an update on a
 reported vulnerability, what to expect if the vulnerability is accepted or
 declined, etc. -->
+
+## 披露时间线 (Disclosure Timeline)
+
+- **0天**：收到漏洞报告后，安全团队将在 **48小时内** 确认收到并开始初步评估。
+- **7天内**：完成漏洞严重性评估，并向报告者反馈初步处理方案。
+- **30天内**：对于确认的漏洞，制定修复计划并开始实施修复。
+- **90天内**：完成漏洞修复并发布安全更新。
+
+在此期间，我们承诺：
+- 与报告者保持透明沟通
+- 在修复发布前不会公开漏洞细节
+- 在修复发布后致谢报告者（除非报告者希望匿名）

--- a/config.py
+++ b/config.py
@@ -332,6 +332,18 @@ ga_key = os.getenv("GA_KEY", "")  # Google Analytics (GA) 密钥, 为空则不�
 # GA 密钥格式为 G-XXXXXXXXXX,
 # 如果为 UA-XXXXXXXXX-X, 请前往GA后台获取新版密钥
 
+# AI 辅助签到设置
+# 兼容 OpenAI Chat Completions 协议的任意服务（OpenAI、DeepSeek、通义、Moonshot、本地 Ollama 等）
+ai_api_key = os.getenv("AI_API_KEY", "")  # 模型服务 API Key, 为空则禁用 AI 功能
+ai_base_url = os.getenv(
+    "AI_BASE_URL", "https://api.openai.com/v1"
+)  # 模型服务 Base URL, 需兼容 OpenAI Chat Completions 协议
+ai_model = os.getenv("AI_MODEL", "gpt-4o-mini")  # 使用的模型名称
+ai_timeout = int(os.getenv("AI_TIMEOUT", "60"))  # AI 请求超时时间(秒)
+ai_max_har_entries = int(
+    os.getenv("AI_MAX_HAR_ENTRIES", "60")
+)  # AI 分析时单个 HAR 文件最多保留的请求数, 防止 token 超限
+
 try:
     from local_config import *  # 修改 `local_config.py` 文件的内容不受通过 Git 更新源码的影响
 

--- a/config.py
+++ b/config.py
@@ -56,7 +56,7 @@ cookie_secure_mode = bool(
 cookie_secret = hashlib.sha256(
     os.getenv("COOKIE_SECRET", "binux").encode("utf-8")
 ).digest()  # Cookie 加密密钥, 强烈建议修改
-pbkdf2_iterations = int(os.getenv("PBKDF2_ITERATIONS", "400"))  # pbkdf2 迭代次数
+pbkdf2_iterations = int(os.getenv("PBKDF2_ITERATIONS", "600000"))  # OWASP recommendation for PBKDF2-SHA256
 aes_key = hashlib.sha256(
     os.getenv("AES_KEY", "binux").encode("utf-8")
 ).digest()  # AES 加密密钥, 强烈建议修改

--- a/db/task.py
+++ b/db/task.py
@@ -104,7 +104,11 @@ class Task(BaseDB, AlchemyMixin):
             smtm = smtm.where(Task.next <= scan_time)
 
         for key, value in kwargs.items():
-            smtm = smtm.where(getattr(Task, key) == value)
+            col = getattr(Task, key)
+            if isinstance(value, (list, tuple, set)):
+                smtm = smtm.where(col.in_(list(value)))
+            else:
+                smtm = smtm.where(col == value)
 
         if limit:
             smtm = smtm.limit(limit)

--- a/db/tasklog.py
+++ b/db/tasklog.py
@@ -47,7 +47,11 @@ class Tasklog(BaseDB, AlchemyMixin):
         smtm = select(_fields)
 
         for key, value in kwargs.items():
-            smtm = smtm.where(getattr(Tasklog, key) == value)
+            col = getattr(Tasklog, key)
+            if isinstance(value, (list, tuple, set)):
+                smtm = smtm.where(col.in_(list(value)))
+            else:
+                smtm = smtm.where(col == value)
 
         if limit:
             smtm = smtm.limit(limit)
@@ -58,4 +62,11 @@ class Tasklog(BaseDB, AlchemyMixin):
         return result
 
     def delete(self, id, sql_session=None):
+        if isinstance(id, (list, tuple, set)):
+            ids = list(id)
+            if not ids:
+                return None
+            return self._delete(
+                delete(Tasklog).where(Tasklog.id.in_(ids)), sql_session=sql_session
+            )
         return self._delete(delete(Tasklog).where(Tasklog.id == id), sql_session=sql_session)

--- a/db/tpl.py
+++ b/db/tpl.py
@@ -106,7 +106,11 @@ class Tpl(BaseDB, AlchemyMixin):
         smtm = select(_fields)
 
         for key, value in kwargs.items():
-            smtm = smtm.where(getattr(Tpl, key) == value)
+            col = getattr(Tpl, key)
+            if isinstance(value, (list, tuple, set)):
+                smtm = smtm.where(col.in_(list(value)))
+            else:
+                smtm = smtm.where(col == value)
 
         if limit:
             smtm = smtm.limit(limit)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   qd:
     image: qdtoday/qd:latest
@@ -27,7 +25,7 @@ services:
       # - COOKIE_DAY=5
       # - COOKIE_SECURE_MODE=False
       - COOKIE_SECRET=binux
-      - PBKDF2_ITERATIONS=400
+      - PBKDF2_ITERATIONS=600000
       - AES_KEY=binux
       # - DB_TYPE=sqlite3
       # - JAWSDB_MARIA_URL=mysql://user:pass@localhost:3306/dbname?auth_plugin=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,13 @@ services:
       # - MAILGUN_KEY=
       # - MAILGUN_DOMAIN=${DOMAIN}
       # - GA_KEY=
+      # AI 辅助签到模板生成（兼容 OpenAI Chat Completions 协议）
+      # 设置 AI_API_KEY 后，HAR 编辑器右上角会出现 "AI 智能识别签到" 按钮
+      # - AI_API_KEY=
+      # - AI_BASE_URL=https://api.openai.com/v1
+      # - AI_MODEL=gpt-4o-mini
+      # - AI_TIMEOUT=60
+      # - AI_MAX_HAR_ENTRIES=60
 
   redis:
     image: redis:alpine

--- a/libs/ai_client.py
+++ b/libs/ai_client.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""
+OpenAI 兼容协议的 AI 客户端，用于辅助生成 QD 签到模板。
+
+支持任意兼容 /v1/chat/completions 的服务：OpenAI、DeepSeek、通义千问、
+Moonshot、本地 Ollama (启用 OpenAI 模式) 等。
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+import config
+
+try:
+    from libs.log import Log  # type: ignore
+
+    logger_ai = Log("QD.AI").getlogger()
+except Exception:  # pragma: no cover - tornado 缺失时退化为标准 logger
+    logger_ai = logging.getLogger("QD.AI")
+
+
+class AIClientError(Exception):
+    """AI 调用失败时抛出。"""
+
+
+class AIClient:
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        model: Optional[str] = None,
+        timeout: Optional[int] = None,
+    ):
+        self.api_key = api_key or config.ai_api_key
+        self.base_url = (base_url or config.ai_base_url).rstrip("/")
+        self.model = model or config.ai_model
+        self.timeout = timeout or config.ai_timeout
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.api_key)
+
+    async def chat(
+        self,
+        messages: List[Dict[str, str]],
+        response_format: Optional[Dict[str, str]] = None,
+        temperature: float = 0.2,
+    ) -> str:
+        if not self.enabled:
+            raise AIClientError("未配置 AI_API_KEY，无法使用 AI 功能")
+
+        # 延迟导入，避免无网络调用的工具函数测试需要 aiohttp
+        import aiohttp
+
+        url = f"{self.base_url}/chat/completions"
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature,
+        }
+        if response_format:
+            payload["response_format"] = response_format
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        timeout = aiohttp.ClientTimeout(total=self.timeout)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(url, json=payload, headers=headers) as resp:
+                    text = await resp.text()
+                    if resp.status >= 400:
+                        raise AIClientError(
+                            f"AI 服务返回 {resp.status}: {text[:500]}"
+                        )
+                    data = json.loads(text)
+        except aiohttp.ClientError as e:
+            raise AIClientError(f"连接 AI 服务失败: {e}") from e
+        except json.JSONDecodeError as e:
+            raise AIClientError(f"AI 响应非合法 JSON: {e}") from e
+
+        try:
+            return data["choices"][0]["message"]["content"] or ""
+        except (KeyError, IndexError, TypeError) as e:
+            raise AIClientError(f"AI 响应结构不符合预期: {data}") from e
+
+
+# ---------- HAR 预处理 ---------- #
+
+# 静态/埋点等噪声请求过滤
+_NOISE_EXT = (
+    ".css", ".js", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg",
+    ".ico", ".woff", ".woff2", ".ttf", ".eot", ".mp4", ".mp3", ".map",
+)
+_NOISE_HOST_KEYWORDS = (
+    "google-analytics", "googletagmanager", "doubleclick", "hotjar",
+    "sentry.io", "bugsnag", "logrocket", "fullstory", "mixpanel",
+    "segment.io", "cdn.jsdelivr", "unpkg.com", "fonts.googleapis",
+    "fonts.gstatic", "baidu.com/hm.js", "cnzz.com", "umeng.com",
+)
+
+
+def _is_noise(entry: Dict[str, Any]) -> bool:
+    try:
+        url = entry["request"]["url"]
+    except (KeyError, TypeError):
+        return True
+    parsed = urlparse(url)
+    path = (parsed.path or "").lower()
+    if any(path.endswith(ext) for ext in _NOISE_EXT):
+        return True
+    host = (parsed.hostname or "").lower()
+    full = f"{host}{parsed.path}".lower()
+    if any(kw in full for kw in _NOISE_HOST_KEYWORDS):
+        return True
+    mime = (
+        entry.get("response", {})
+        .get("content", {})
+        .get("mimeType", "")
+        .lower()
+    )
+    if mime.startswith(("image/", "font/", "video/", "audio/", "text/css")):
+        return True
+    if "javascript" in mime and "json" not in mime:
+        return True
+    return False
+
+
+def _slim_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """裁剪单个 HAR entry 仅保留 AI 需要的字段。"""
+    req = entry.get("request", {})
+    resp = entry.get("response", {})
+    headers = req.get("headers", []) or []
+    cookies = req.get("cookies", []) or []
+    # 只保留有信息量的请求头
+    keep_headers = {
+        "content-type", "accept", "x-requested-with", "referer",
+        "origin", "authorization", "x-csrf-token",
+    }
+    slim_headers = [
+        {"name": h.get("name", ""), "value": h.get("value", "")[:200]}
+        for h in headers
+        if h.get("name", "").lower() in keep_headers
+    ]
+    post_data = req.get("postData", {}) or {}
+    body_text = post_data.get("text", "") or ""
+    if len(body_text) > 500:
+        body_text = body_text[:500] + "...(truncated)"
+
+    resp_content = (resp.get("content", {}) or {}).get("text", "") or ""
+    if len(resp_content) > 400:
+        resp_content = resp_content[:400] + "...(truncated)"
+
+    return {
+        "method": req.get("method", "GET"),
+        "url": req.get("url", "")[:500],
+        "headers": slim_headers,
+        "cookieNames": [c.get("name", "") for c in cookies][:10],
+        "body": body_text,
+        "respStatus": resp.get("status", 0),
+        "respMime": (resp.get("content", {}) or {}).get("mimeType", ""),
+        "respPreview": resp_content,
+    }
+
+
+def preprocess_har(har_data: Dict[str, Any], max_entries: int) -> List[Dict[str, Any]]:
+    """过滤静态资源后裁剪 entries。返回供 LLM 分析的精简列表。"""
+    entries = (har_data.get("log", {}) or {}).get("entries", []) or []
+    filtered = [e for e in entries if not _is_noise(e)]
+    # 优先保留 POST/PUT 等修改类请求（签到通常是 POST/GET）
+    filtered.sort(
+        key=lambda e: (
+            0 if e.get("request", {}).get("method", "GET").upper() != "GET" else 1
+        )
+    )
+    return [_slim_entry(e) for e in filtered[:max_entries]]
+
+
+# ---------- Prompt 构造 ---------- #
+
+_SYSTEM_PROMPT = """你是一个 HTTP 抓包分析助手。用户会给你一个浏览器抓包的 HAR 精简数据，
+你的任务是从中识别出"签到 / 打卡 / check-in"操作真正发起的关键请求（通常只有 1-3 条），
+忽略静态资源、心跳、埋点、广告、首页拉取等。
+
+只输出严格 JSON，不要 markdown 包裹，不要解释，结构如下：
+{
+  "sitename": "站点名称（猜测）",
+  "siteurl": "站点首页 URL",
+  "note": "操作说明，10-50 字",
+  "entries": [
+    {
+      "method": "POST",
+      "url": "签到接口完整 URL",
+      "headers": [{"name": "Content-Type", "value": "application/json"}],
+      "body": "可能的请求体",
+      "reason": "为什么判断这是签到请求（5-30 字）"
+    }
+  ],
+  "variables": ["需要用户提供的变量名，如 cookie / token"],
+  "success_keyword": "响应中表示签到成功的关键字（如 已签到 / success）"
+}
+
+判断要点：
+1. 优先选择 POST 且 path 含 sign / check / clock / daily / attend / punch 等关键词的请求
+2. 同一接口出现多次时只保留一次
+3. 不要把登录请求当作签到请求，除非确无单独签到接口
+4. 如果实在找不到签到请求，entries 返回空数组并在 note 中说明
+"""
+
+
+def build_messages(
+    slim_entries: List[Dict[str, Any]], hint: str = ""
+) -> List[Dict[str, str]]:
+    user_payload = {
+        "hint": hint or "",
+        "entries": slim_entries,
+    }
+    return [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": (
+                "请基于以下抓包数据识别签到请求。数据使用 JSON：\n```json\n"
+                + json.dumps(user_payload, ensure_ascii=False)
+                + "\n```"
+            ),
+        },
+    ]
+
+
+def parse_ai_response(content: str) -> Dict[str, Any]:
+    """容错解析 AI 输出 JSON。"""
+    raw = content.strip()
+    if raw.startswith("```"):
+        # 去掉 ```json ... ``` 包裹
+        raw = raw.strip("`")
+        if raw.lower().startswith("json"):
+            raw = raw[4:]
+        raw = raw.strip()
+        if raw.endswith("```"):
+            raw = raw[:-3].strip()
+    # 兜底：截取首个 { ... } 区段
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start >= 0 and end > start:
+        raw = raw[start : end + 1]
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise AIClientError(f"AI 输出不是合法 JSON: {e}; 原文: {content[:300]}") from e
+
+
+def ai_result_to_har(result: Dict[str, Any]) -> Dict[str, Any]:
+    """把 AI 输出转成 QD 编辑器可加载的 HAR 结构。"""
+    har_entries: List[Dict[str, Any]] = []
+    for item in result.get("entries", []) or []:
+        method = (item.get("method") or "GET").upper()
+        url = item.get("url") or ""
+        headers = []
+        for h in item.get("headers", []) or []:
+            if not isinstance(h, dict):
+                continue
+            headers.append(
+                {"name": str(h.get("name", "")), "value": str(h.get("value", ""))}
+            )
+        body = item.get("body") or ""
+        post_data = (
+            {
+                "mimeType": next(
+                    (
+                        h["value"]
+                        for h in headers
+                        if h["name"].lower() == "content-type"
+                    ),
+                    "application/x-www-form-urlencoded",
+                ),
+                "text": body,
+            }
+            if body
+            else None
+        )
+        entry: Dict[str, Any] = {
+            "request": {
+                "method": method,
+                "url": url,
+                "headers": headers,
+                "cookies": [],
+                "queryString": [],
+                "httpVersion": "HTTP/1.1",
+                "headersSize": -1,
+                "bodySize": len(body) if body else 0,
+            },
+            "response": {
+                "status": 200,
+                "statusText": "OK",
+                "headers": [],
+                "cookies": [],
+                "content": {"size": 0, "mimeType": "text/plain", "text": ""},
+                "redirectURL": "",
+                "headersSize": -1,
+                "bodySize": -1,
+            },
+            "startedDateTime": "",
+            "time": 0,
+            "cache": {},
+            "timings": {"send": 0, "wait": 0, "receive": 0},
+            "_ai_reason": item.get("reason", ""),
+        }
+        if post_data:
+            entry["request"]["postData"] = post_data
+        har_entries.append(entry)
+
+    return {
+        "log": {
+            "version": "1.2",
+            "creator": {"name": "QD AI", "version": "1.0"},
+            "pages": [],
+            "entries": har_entries,
+        }
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true

--- a/qd.py
+++ b/qd.py
@@ -23,16 +23,16 @@ logger_qd = Log("QD").getlogger()
 
 
 def check_port(port):
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.settimeout(5)
-    try:
-        s.connect(("127.0.0.1", port))
-        s.shutdown(2)
-        logger_qd.debug("Port %s is used", port)
-        return False
-    except Exception:
-        logger_qd.debug("Port %s is available", port)
-        return True
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(5)
+        try:
+            s.connect(("127.0.0.1", port))
+            s.shutdown(socket.SHUT_RDWR)
+            logger_qd.debug("Port %s is used", port)
+            return False
+        except (ConnectionRefusedError, OSError):
+            logger_qd.debug("Port %s is available", port)
+            return True
 
 
 def usage():

--- a/qd.py
+++ b/qd.py
@@ -48,7 +48,8 @@ if __name__ == "__main__":
     tpl_file = sys.argv[1]
     try:
         # deepcode ignore PT: tpl_file is a file
-        tpl = json.load(open(tpl_file, encoding="utf-8"))
+        with open(tpl_file, encoding="utf-8") as _f:
+            tpl = json.load(_f)
     except Exception as e:
         logger_qd.error(e, exc_info=config.traceback_print)
         usage()
@@ -67,7 +68,8 @@ if __name__ == "__main__":
     if ENV_FILE:
         try:
             # deepcode ignore PT: env_file is a file
-            env = json.load(open(ENV_FILE, encoding="utf-8"))
+            with open(ENV_FILE, encoding="utf-8") as _f:
+                env = json.load(_f)
         except Exception as e:
             logger_qd.error(e, exc_info=config.traceback_print)
             usage()

--- a/run.py
+++ b/run.py
@@ -58,7 +58,8 @@ def start_server():
         converter = db_converter.DBconverter(database)
         asyncio.run(converter.convert_new_type(database))
 
-        default_version = json.load(open(os.path.join(os.path.dirname(__file__), 'version.json'), 'r', encoding='utf-8'))['version']
+        with open(os.path.join(os.path.dirname(__file__), 'version.json'), 'r', encoding='utf-8') as _f:
+        default_version = json.load(_f)['version']
         app = Application(database, default_version)
         http_server = HTTPServer(app, xheaders=True)
         http_server.bind(port, config.bind)

--- a/run.py
+++ b/run.py
@@ -26,6 +26,30 @@ if sys.getdefaultencoding() != 'utf-8':
     importlib.reload(sys)
 
 
+def _check_default_secrets(logger):
+    """启动时检查关键密钥是否仍为默认值，是则醒目告警。
+
+    生产部署（特别是 Docker 镜像）极易忘记覆盖默认 Cookie/AES 密钥，
+    本检查不会阻止启动，但会输出 WARNING 提示用户。
+    """
+    import hashlib
+    default_secret = hashlib.sha256(b'binux').digest()
+    if config.cookie_secret == default_secret:
+        logger.warning(
+            "[安全] COOKIE_SECRET 未设置, 当前为默认值 'binux'。"
+            "强烈建议通过环境变量覆盖, 例如: -e COOKIE_SECRET=$(openssl rand -hex 32)"
+        )
+    if config.aes_key == default_secret:
+        logger.warning(
+            "[安全] AES_KEY 未设置, 当前为默认值 'binux'。"
+            "已存储的加密数据可被任何人解密, 建议生产环境覆盖该变量。"
+        )
+    if not config.domain:
+        logger.warning(
+            "[配置] DOMAIN 未设置, 邮件链接、推送链接将无法生成正确域名。"
+        )
+
+
 def start_server():
     # init logging
     logger = Log().getlogger()
@@ -53,13 +77,15 @@ def start_server():
     if config.multiprocess and config.autoreload:
         config.autoreload = False
 
+    _check_default_secrets(logger_qd)
+
     try:
         database = DB()
         converter = db_converter.DBconverter(database)
         asyncio.run(converter.convert_new_type(database))
 
         with open(os.path.join(os.path.dirname(__file__), 'version.json'), 'r', encoding='utf-8') as _f:
-        default_version = json.load(_f)['version']
+            default_version = json.load(_f)['version']
         app = Application(database, default_version)
         http_server = HTTPServer(app, xheaders=True)
         http_server.bind(port, config.bind)

--- a/run.py
+++ b/run.py
@@ -56,10 +56,7 @@ def start_server():
     try:
         database = DB()
         converter = db_converter.DBconverter(database)
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        run = asyncio.ensure_future(converter.convert_new_type(database) , loop=loop)
-        loop.run_until_complete(run)
+        asyncio.run(converter.convert_new_type(database))
 
         default_version = json.load(open(os.path.join(os.path.dirname(__file__), 'version.json'), 'r', encoding='utf-8'))['version']
         app = Application(database, default_version)
@@ -88,10 +85,7 @@ def start_server():
         io_loop.start()
     except KeyboardInterrupt :
         logger_qd.info("Http Server is being manually interrupted... ")
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        run = asyncio.ensure_future(engine.dispose() , loop=loop)
-        loop.run_until_complete(run)
+        asyncio.run(engine.dispose())
         logger_qd.info("Http Server is ended. ")
 
 

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -1,0 +1,155 @@
+"""Tests for libs.ai_client (HAR preprocessing & response parsing)."""
+import unittest
+
+
+class TestPreprocessHar(unittest.TestCase):
+    def _make_entry(self, url, method="GET", mime="application/json", body=""):
+        return {
+            "request": {
+                "method": method,
+                "url": url,
+                "headers": [
+                    {"name": "Content-Type", "value": "application/json"},
+                    {"name": "User-Agent", "value": "x"},  # 应被过滤
+                ],
+                "cookies": [{"name": "session", "value": "abc"}],
+                "postData": {"mimeType": "application/json", "text": body},
+            },
+            "response": {
+                "status": 200,
+                "content": {"mimeType": mime, "text": "ok"},
+            },
+        }
+
+    def test_filters_static_resources(self):
+        from libs.ai_client import preprocess_har
+        har = {
+            "log": {
+                "entries": [
+                    self._make_entry("https://x.com/a.js", mime="application/javascript"),
+                    self._make_entry("https://x.com/style.css", mime="text/css"),
+                    self._make_entry("https://x.com/img.png", mime="image/png"),
+                    self._make_entry("https://x.com/api/sign", method="POST"),
+                ]
+            }
+        }
+        out = preprocess_har(har, max_entries=10)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["url"], "https://x.com/api/sign")
+        self.assertEqual(out[0]["method"], "POST")
+
+    def test_filters_analytics(self):
+        from libs.ai_client import preprocess_har
+        har = {
+            "log": {
+                "entries": [
+                    self._make_entry("https://www.google-analytics.com/collect"),
+                    self._make_entry("https://api.x.com/check_in", method="POST"),
+                ]
+            }
+        }
+        out = preprocess_har(har, max_entries=10)
+        urls = [e["url"] for e in out]
+        self.assertNotIn("https://www.google-analytics.com/collect", urls)
+        self.assertIn("https://api.x.com/check_in", urls)
+
+    def test_keeps_relevant_headers_only(self):
+        from libs.ai_client import preprocess_har
+        har = {"log": {"entries": [self._make_entry("https://x.com/api/sign", "POST")]}}
+        out = preprocess_har(har, max_entries=10)
+        names = {h["name"].lower() for h in out[0]["headers"]}
+        self.assertIn("content-type", names)
+        self.assertNotIn("user-agent", names)
+
+    def test_max_entries_limit(self):
+        from libs.ai_client import preprocess_har
+        har = {
+            "log": {
+                "entries": [
+                    self._make_entry(f"https://x.com/api/n{i}", "POST")
+                    for i in range(50)
+                ]
+            }
+        }
+        out = preprocess_har(har, max_entries=5)
+        self.assertEqual(len(out), 5)
+
+    def test_post_methods_prioritized(self):
+        from libs.ai_client import preprocess_har
+        har = {
+            "log": {
+                "entries": [
+                    self._make_entry("https://x.com/list", "GET"),
+                    self._make_entry("https://x.com/sign", "POST"),
+                ]
+            }
+        }
+        out = preprocess_har(har, max_entries=10)
+        # POST 应排在前面
+        self.assertEqual(out[0]["method"], "POST")
+
+
+class TestParseAIResponse(unittest.TestCase):
+    def test_plain_json(self):
+        from libs.ai_client import parse_ai_response
+        result = parse_ai_response('{"sitename": "x", "entries": []}')
+        self.assertEqual(result["sitename"], "x")
+
+    def test_markdown_wrapped(self):
+        from libs.ai_client import parse_ai_response
+        result = parse_ai_response('```json\n{"sitename": "y", "entries": []}\n```')
+        self.assertEqual(result["sitename"], "y")
+
+    def test_with_extra_text(self):
+        from libs.ai_client import parse_ai_response
+        result = parse_ai_response(
+            'Here is the result:\n{"sitename": "z", "entries": []}\nThanks.'
+        )
+        self.assertEqual(result["sitename"], "z")
+
+    def test_invalid_json_raises(self):
+        from libs.ai_client import AIClientError, parse_ai_response
+        with self.assertRaises(AIClientError):
+            parse_ai_response("not json at all")
+
+
+class TestAIResultToHar(unittest.TestCase):
+    def test_basic_conversion(self):
+        from libs.ai_client import ai_result_to_har
+        result = {
+            "sitename": "Demo",
+            "entries": [
+                {
+                    "method": "POST",
+                    "url": "https://api.demo.com/sign",
+                    "headers": [
+                        {"name": "Content-Type", "value": "application/json"}
+                    ],
+                    "body": '{"action":"sign"}',
+                    "reason": "POST 路径含 sign",
+                }
+            ],
+        }
+        har = ai_result_to_har(result)
+        self.assertEqual(len(har["log"]["entries"]), 1)
+        e = har["log"]["entries"][0]
+        self.assertEqual(e["request"]["method"], "POST")
+        self.assertEqual(e["request"]["url"], "https://api.demo.com/sign")
+        self.assertIn("postData", e["request"])
+        self.assertEqual(e["request"]["postData"]["text"], '{"action":"sign"}')
+
+    def test_empty_entries(self):
+        from libs.ai_client import ai_result_to_har
+        har = ai_result_to_har({"entries": []})
+        self.assertEqual(har["log"]["entries"], [])
+
+
+class TestAIClientDisabled(unittest.TestCase):
+    def test_disabled_when_no_key(self):
+        from libs.ai_client import AIClient
+        client = AIClient(api_key="")
+        self.assertFalse(client.enabled)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,31 @@
+"""Basic configuration tests."""
+import os
+import unittest
+
+
+class TestConfig(unittest.TestCase):
+    """Test configuration defaults."""
+
+    def test_config_import(self):
+        """Test that config module can be imported."""
+        import config
+        self.assertIsNotNone(config)
+
+    def test_port_default(self):
+        """Test default port value."""
+        import config
+        self.assertEqual(config.port, int(os.getenv("PORT", "8923")))
+
+    def test_bind_default(self):
+        """Test default bind address."""
+        import config
+        self.assertEqual(config.bind, os.getenv("BIND", "0.0.0.0"))
+
+    def test_db_type_valid(self):
+        """Test db_type is a valid option."""
+        import config
+        self.assertIn(config.db_type, ("sqlite3", "mysql"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,57 @@
+"""Utility function tests."""
+import unittest
+
+
+class TestUtils(unittest.TestCase):
+    """Test utility functions."""
+
+    def test_ip2int_loopback(self):
+        """Test IP to int conversion for loopback."""
+        from libs.utils import ip2int
+        result = ip2int("127.0.0.1")
+        self.assertEqual(result, 2130706433)
+
+    def test_int2ip_loopback(self):
+        """Test int to IP conversion for loopback."""
+        from libs.utils import int2ip
+        result = int2ip(2130706433)
+        self.assertEqual(result, "127.0.0.1")
+
+    def test_is_lan_private(self):
+        """Test LAN detection for private IP."""
+        from libs.utils import is_lan
+        self.assertTrue(is_lan("192.168.1.1"))
+        self.assertTrue(is_lan("10.0.0.1"))
+        self.assertTrue(is_lan("172.16.0.1"))
+
+    def test_is_lan_public(self):
+        """Test LAN detection for public IP."""
+        from libs.utils import is_lan
+        self.assertFalse(is_lan("8.8.8.8"))
+
+    def test_is_ip_v4(self):
+        """Test IPv4 detection."""
+        from libs.utils import is_ip
+        self.assertEqual(is_ip("192.168.1.1"), 4)
+
+    def test_is_ip_v6(self):
+        """Test IPv6 detection."""
+        from libs.utils import is_ip
+        self.assertEqual(is_ip("::1"), 6)
+
+    def test_is_ip_invalid(self):
+        """Test invalid IP detection."""
+        from libs.utils import is_ip
+        self.assertEqual(is_ip("not.an.ip"), 0)
+
+    def test_varbinary2ip_v4(self):
+        """Test varbinary to IPv4 conversion."""
+        from libs.utils import varbinary2ip, ip2varbinary
+        ip = "192.168.1.1"
+        binary = ip2varbinary(ip, 4)
+        result = varbinary2ip(binary)
+        self.assertEqual(result, ip)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/docs/zh_CN/guide/ai-sign-template.md
+++ b/web/docs/zh_CN/guide/ai-sign-template.md
@@ -1,0 +1,173 @@
+# 使用 AI 自动生成签到模板
+
+> QD 框架在 HAR 编辑器中内置了 **AI 智能识别签到** 功能：上传抓包后一键调用大模型，自动从几十上百条请求中挑出真正的签到接口，跳过手动剔除噪声请求的繁琐过程。
+
+> 本教程基于 PR：`feat: AI 智能签到识别 + worker N+1 优化与安全告警`。
+
+## 一、功能概述
+
+- **输入**：浏览器或客户端导出的 HAR 文件（参见 [HAR 抓包教程](./har-capture.md)）。
+- **输出**：一份只包含 1-3 条关键签到请求的最小化 HAR，可直接保存为 QD 模板执行。
+- **底层协议**：兼容 OpenAI Chat Completions（`/v1/chat/completions`）。
+  - 可对接 **OpenAI**、**DeepSeek**、**通义千问**、**Moonshot**、**OpenRouter** 等云服务；
+  - 也可对接 **本地 Ollama / LM Studio / vLLM**（开启 OpenAI 兼容模式即可）。
+
+---
+
+## 二、启用 AI 功能
+
+### 2.1 准备 API Key
+
+挑一家提供 OpenAI 兼容协议的服务商，注册后拿到 API Key。下表是常见可选项（任选其一）：
+
+| 服务 | Base URL | 推荐模型 |
+| --- | --- | --- |
+| OpenAI | `https://api.openai.com/v1` | `gpt-4o-mini` / `gpt-4o` |
+| DeepSeek | `https://api.deepseek.com/v1` | `deepseek-chat` |
+| 通义千问（阿里云 DashScope） | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen-plus` / `qwen2.5-72b-instruct` |
+| Moonshot | `https://api.moonshot.cn/v1` | `moonshot-v1-8k` |
+| OpenRouter | `https://openrouter.ai/api/v1` | 任意模型 ID |
+| 本地 Ollama | `http://localhost:11434/v1` | `qwen2.5:14b` 等 |
+
+### 2.2 配置环境变量
+
+在 `docker-compose.yml` 中找到 QD 服务的 `environment` 段，加入：
+
+```yaml
+services:
+  qd:
+    environment:
+      - AI_API_KEY=sk-xxxxxxxxxxxxxxxx       # 必填，留空即关闭功能
+      - AI_BASE_URL=https://api.deepseek.com/v1   # 可选，默认 https://api.openai.com/v1
+      - AI_MODEL=deepseek-chat                # 可选，默认 gpt-4o-mini
+      - AI_TIMEOUT=60                         # 可选，单次请求超时秒数
+      - AI_MAX_HAR_ENTRIES=60                 # 可选，单 HAR 最多保留多少条请求送给 AI
+```
+
+非 Docker 部署可直接 `export AI_API_KEY=sk-xxx` 后再启动 `python run.py`，或写到 `local_config.py`。
+
+### 2.3 重启生效
+
+```bash
+docker compose up -d --force-recreate qd
+```
+
+启动日志若不再出现 `[安全] COOKIE_SECRET 未设置...` 等告警即代表 QD 已成功读取你的环境变量。
+
+### 2.4 验证
+
+打开任意一个 HAR 编辑器页面（侧栏「HAR 模板」 → 新建 / 编辑任一模板），看右上角的按钮区域：
+
+- 出现 **「AI 智能识别签到」** 按钮 → 启用成功。
+- 仍未出现，或弹窗提示 `AI 功能未启用` → 检查环境变量是否生效（容器内执行 `env | grep AI_`）。
+
+也可以直接请求接口：
+
+```bash
+curl http://your-qd-host:8923/har/ai_status
+# {"enabled": true, "model": "deepseek-chat"}
+```
+
+---
+
+## 三、操作步骤
+
+### 第 1 步：准备 HAR
+
+按 [HAR 抓包教程](./har-capture.md) 抓出一份 `.har` 文件，**确保里面包含一次完整的签到操作**。
+
+### 第 2 步：进入 HAR 编辑器并导入
+
+1. 在 QD 顶部菜单进入 **HAR 模板**，点 **新建**（或编辑任意已有模板）。
+2. 点击 **追加 HAR** → 选择 `.har` 文件 → **上传**。
+3. 此时左侧会出现几十甚至上百条请求。
+
+### 第 3 步：AI 智能识别
+
+1. 点右上角 **「AI 智能识别签到」** 按钮。
+2. 弹窗中：
+   - **提示词（可选）**：留空也能跑。如果你知道签到的中文叫法，可以填「每日签到」「积分领取」「打卡」等关键词，识别准确率更高。
+   - 当 AI 配置正确时会显示当前模型名（如 `deepseek-chat`）。
+3. 点 **开始分析**，等待 5-30 秒（取决于模型与网络）。
+4. 分析完成后弹窗下方会显示 AI 给出的 JSON 结果，包括：
+   - `sitename` / `siteurl` / `note` —— 站点信息建议
+   - `entries[]` —— 识别出的关键请求（含原始 URL、Method、Body、识别理由）
+   - `variables[]` —— 提示你需要补哪些变量（通常是 cookie / token）
+   - `success_keyword` —— 签到成功响应中的关键字
+5. 检查无误后点 **应用为当前模板**：编辑器中所有原始请求会被替换为 AI 给出的最小集合。
+
+### 第 4 步：补充变量并测试
+
+1. 编辑器右侧是变量面板，AI 一般会建议 `cookie` 等变量。点 **测试**。
+2. 在测试弹窗里填入 `cookie`（可点 `点击获取` 借助 Get-Cookies 浏览器插件），其他变量按需填写。
+3. 点击 **测试**，看响应是否包含「签到成功」「已签到」等关键字。
+4. 测试通过后，回到编辑器点 **保存**。
+
+### 第 5 步：创建任务
+
+回到「HAR 模板」列表 → 选中刚保存的模板 → **新建任务**，填写定时表达式（如 `0 8 * * *` 每天早 8 点），保存即可。
+
+---
+
+## 四、提示词使用建议
+
+提示词不是必填，但能显著提高识别精度。以下是典型场景：
+
+- **签到名称不是「签到」**：填「积分」「打卡」「补卡」「采集」「领取」等真实按钮文案。
+- **HAR 中混入了多个站点**：填站点名 + 操作，例如 `bilibili 视频心跳` 或 `nas-tools 每日刷流`。
+- **明确排除某类请求**：填「忽略登录请求，只要签到接口」。
+- **多步签到**：填「签到接口可能需要先获取 token 再 POST，请按顺序返回」。
+
+---
+
+## 五、AI 工作原理（FAQ）
+
+**Q: AI 会泄漏我的 Cookie / Token 吗？**
+- 后端在送给 AI 之前会做预处理：仅保留 `Content-Type` / `Referer` / `Origin` / `Authorization` / `X-CSRF-Token` 等少量必要 header；Cookie 只送 **名称**（不送值）；请求体超过 500 字符会截断。
+- 你的 API Key 调用的是你自己选定的 `AI_BASE_URL`，请确认那是可信服务。如果非常敏感，建议用本地 Ollama。
+
+**Q: AI 给出的结果不对怎么办？**
+- 重新点 **开始分析** 重试一次（AI 输出有随机性）。
+- 在「提示词」里写得更具体。
+- 改用更强的模型（如 `gpt-4o`、`deepseek-chat`、`qwen2.5-72b-instruct`）。
+- 若仍不行，AI 给出的 JSON 可作为参考，手动在编辑器里调整请求列表。
+
+**Q: 一次请求消耗多少 Token？**
+- HAR 经预处理后每条 entry 大概 0.2-0.5 KB，默认上限 60 条 = ~30 KB ≈ 8K-12K input tokens。
+- 输出极短（一般 < 1K tokens）。
+- 用 `gpt-4o-mini` 单次费用约 0.001 美元；DeepSeek、通义更便宜。
+
+**Q: 返回 502 / 超时？**
+- 模型服务挂了或被墙，换 `AI_BASE_URL`。
+- 调高 `AI_TIMEOUT`（最大可设到 300 秒）。
+- HAR 太大，调小 `AI_MAX_HAR_ENTRIES`（如 30）。
+
+**Q: 我能否在没有图形界面的情况下调用？**
+- 可以。后端暴露了 REST 接口：
+
+  ```bash
+  curl -X POST http://your-qd-host:8923/har/ai_analyze \
+       -H 'Content-Type: application/json' \
+       -H "Cookie: $(your-login-cookie)" \
+       --data-binary @payload.json
+  # payload.json: {"har": <HAR JSON>, "hint": "每日签到"}
+  ```
+  返回 `{ok: true, har: ..., result: ...}`。
+
+---
+
+## 六、安全与合规
+
+1. **不要把生产 API Key 写进公共仓库**。Docker 部署用 `.env` 文件；裸机部署用 `local_config.py` 并加入 `.gitignore`。
+2. **抓包前阅读目标站点的服务条款**：自动化签到在某些站点上是被允许的（积分、签到送奖励），在某些 SaaS 上明确禁止 —— 自己评估风险。
+3. **不要替朋友 / 网友抓 HAR**：HAR 内含完整身份凭据，本质上等同于「把账号给别人」。
+4. **建议使用本地模型**：长期高频使用建议 Ollama + Qwen2.5 14B / 32B，零外发数据，离线可用。
+
+---
+
+## 七、相关链接
+
+- [QD 官方文档](https://qd-today.github.io/qd/zh_CN/)
+- [HAR 抓包教程](./har-capture.md)
+- [使用指南：如何使用](./how-to-use.md)
+- [常见问题](./faq.md)

--- a/web/docs/zh_CN/guide/har-capture.md
+++ b/web/docs/zh_CN/guide/har-capture.md
@@ -1,0 +1,160 @@
+# HAR 抓包教程
+
+> 本文档介绍如何在 **网页浏览器** 和 **桌面 / 移动客户端抓包工具** 中导出 HAR 文件，供 QD 框架直接导入或交给 [AI 自动识别签到接口](./ai-sign-template.md)。
+
+## 一、什么是 HAR？
+
+HAR（**H**TTP **A**rchive）是一种 JSON 格式的浏览器抓包记录，包含完整的请求 URL、方法、Headers、Cookies、Body 与响应内容。QD 框架的核心是「重放 HAR 中的请求」，因此抓出一份正确的 HAR 是创建签到任务的第一步。
+
+> 在线分析工具：<https://toolbox.googleapps.com/apps/har_analyzer/?lang=zh_CN>
+
+## 二、抓包前的通用准备
+
+无论用哪款工具，都建议：
+
+1. **登录目标网站**：先用浏览器手动登录到能看到「签到」按钮的页面。
+2. **关闭所有无关标签页**：减少干扰请求。
+3. **确认是否需要二步验证 / 验证码**：如果有，请在抓包前完成。
+4. **新开一个隐身窗口** 或 **清空网络面板** 后再开始抓包，得到的 HAR 更干净。
+
+> 隐私提醒：HAR 中可能包含 Cookie、Token、邮箱等敏感信息，**不要直接发到聊天群、论坛**。如果上传到 QD 的 AI 分析功能，请确认你的 `AI_BASE_URL` 是可信服务（OpenAI、自部署 Ollama 等）。
+
+---
+
+## 三、浏览器（推荐，最简单）
+
+### 3.1 Chrome / Edge / 国产 Chromium 浏览器
+
+1. 在已登录的目标网站页面按 `F12` 或 `Ctrl + Shift + I`（macOS：`⌥ + ⌘ + I`），打开开发者工具。
+2. 切到顶部的 **Network（网络）** 选项卡。
+3. 确认左上角 **录制按钮（红色圆点）** 处于亮起状态；如果是灰色的，点一下让它变红。
+4. 勾选 **Preserve log（保留日志）**，避免页面跳转后日志被清空。
+5. 点击 **🚫 Clear（清除）** 按钮清空已有日志。
+6. **现在去网页上手动点一次「签到」按钮**，等待页面提示签到成功。
+7. 在请求列表区域 **右键 → Save all as HAR with content（另存为带内容的 HAR）**。
+8. 选择保存位置，得到一个 `.har` 文件。
+
+> 小技巧：如果签到流程包含跳转或弹窗，建议保持「Preserve log」一直勾选。
+
+### 3.2 Firefox
+
+1. 按 `F12` 打开开发者工具，切到 **网络** 面板。
+2. 在面板顶部勾选 **持续日志（Persist Logs）**。
+3. 点击 **垃圾桶图标** 清空。
+4. 在页面上完成一次签到操作。
+5. 在请求列表 **右键 → 全部另存为 HAR**。
+
+### 3.3 Safari（macOS）
+
+1. 先在 **Safari → 设置 → 高级** 中勾选「在菜单栏中显示开发菜单」。
+2. 顶部菜单 **开发 → 显示 Web 检查器**。
+3. 切到 **网络** 面板，点击 **导出** 按钮即可下载 HAR。
+
+---
+
+## 四、桌面客户端抓包工具
+
+### 4.1 Fiddler Classic（Windows）
+
+适合需要抓 **桌面客户端 / 老版本 IE / 不暴露给浏览器调试** 的请求。
+
+1. 安装并打开 [Fiddler Classic](https://www.telerik.com/fiddler/fiddler-classic)。
+2. 顶部菜单 **Tools → Options**。
+   - **HTTPS** 选项卡：勾选 `Capture HTTPS CONNECTs` 与 `Decrypt HTTPS traffic`。第一次会弹窗安装根证书，**必须点击「是」**，否则抓不到 HTTPS 内容。
+   - **Connections** 选项卡：默认监听端口 8888，勾选 `Allow remote computers to connect`（如需手机抓包）。
+3. 重启 Fiddler 后，在浏览器或客户端里完成签到操作。
+4. 在左侧请求列表选中相关请求（按住 `Ctrl` 多选；或使用 `Ctrl+A` 全选）。
+5. 顶部菜单 **File → Export Sessions → Selected Sessions...**，选择 **HTTPArchive v1.2** 格式，导出为 `.har`。
+
+### 4.2 Charles（Windows / macOS）
+
+1. 安装 [Charles Proxy](https://www.charlesproxy.com/)，**Help → SSL Proxying → Install Charles Root Certificate**，按提示信任证书。
+2. **Proxy → SSL Proxying Settings**，勾选 `Enable SSL Proxying`，添加目标域名（例如 `*.example.com:443`）。
+3. 让客户端走 Charles 代理（Charles 会自动配置系统代理；macOS 也可以走 Charles 自己的端口 8888）。
+4. 在客户端里完成签到操作。
+5. 顶部菜单 **File → Export Session...**，选择 **HTTP Archive (.har)**。
+
+### 4.3 mitmproxy / mitmweb（跨平台命令行）
+
+适合开发者，纯本地运行：
+
+```bash
+# 1. 安装
+pip install mitmproxy
+
+# 2. 启动 web 界面，监听 8080 端口
+mitmweb --listen-port 8080
+
+# 3. 浏览器访问 http://mitm.it 安装根证书（按提示选系统）
+# 4. 让客户端走 127.0.0.1:8080 代理
+# 5. 完成签到操作
+# 6. 在 mitmweb 界面 File → Save，选 HAR
+```
+
+或者纯命令行抓出 HAR：
+
+```bash
+mitmdump -s "$(python -c 'import mitmproxy.addons.savehar; print(mitmproxy.addons.savehar.__file__)')" -w out.har
+```
+
+### 4.4 Wireshark（不推荐用于 QD）
+
+Wireshark 抓的是裸 TCP 包而非 HAR，需要解 TLS 才能看到 HTTPS 明文，**不能直接导出 QD 可用的 HAR**，不建议用于本场景。
+
+---
+
+## 五、移动端抓包
+
+### 5.1 Android
+
+1. 在电脑上启动 Charles / Fiddler / mitmproxy。
+2. 手机和电脑连同一个 Wi-Fi。
+3. **设置 → 无线和网络 → Wi-Fi → 长按当前网络 → 修改网络 → 高级 → 代理 → 手动**，填写电脑 IP + 抓包工具端口。
+4. 浏览器访问对应工具的证书页（Charles 是 `chls.pro/ssl`，mitm 是 `mitm.it`），下载并 **设为「VPN 与应用」证书**。
+5. **Android 7+** 默认不再信任用户证书，需要：
+   - 应用是 debug 版：在 `network_security_config.xml` 显式信任用户 CA；
+   - 或使用 Magisk 模块 `MoveCertificates` 把用户 CA 提升为系统 CA（需要 Root）。
+6. 在目标 App 中完成签到，在抓包工具中导出 HAR。
+
+### 5.2 iOS
+
+1. 同上让 iOS 走电脑代理。
+2. Safari 访问 `chls.pro/ssl` 下载描述文件 → **设置 → 通用 → VPN与设备管理** 安装。
+3. **设置 → 通用 → 关于本机 → 证书信任设置**，把 Charles 证书的开关 **手动打开**（这一步极易忘）。
+4. 完成签到，导出 HAR。
+
+### 5.3 Stream / HttpCanary / 小黄鸟（移动原生抓包）
+
+- iOS 上的 **Stream** 或 **Thor** App、Android 上的 **HttpCanary（小黄鸟）**、**Reqable** 都可以原生抓包。
+- 抓到目标请求后，可以用「导出 → HAR」或「分享为文件」得到 `.har`。
+
+---
+
+## 六、抓包效果验证
+
+抓完后 **务必先自己检查一遍** 再交给 QD：
+
+1. 用文本编辑器打开 `.har`，搜索关键字（如 `sign`、`check`、`daily`）确认有相关请求。
+2. 在 Chrome DevTools 里把 HAR **拖回 Network 面板**重新查看，可以可视化检查每条请求。
+3. 检查 Cookie、Token 是否完整。如果是 OAuth Bearer Token，注意 Token 有效期，过期后需要重抓。
+
+---
+
+## 七、常见问题
+
+| 问题 | 处理 |
+| --- | --- |
+| HTTPS 请求看不到内容（显示 Tunnel） | 没装根证书，按对应工具说明重装 |
+| 抓到的 HAR 没有响应体 | 导出时漏勾「with content」/「保留响应体」 |
+| 部分请求被「证书绑定（Pinning）」拒绝 | 用 SSLUnpinning 模块、Frida 脚本，或换调试版 App |
+| 文件超过 50 MB QD 不让上传 | 在 DevTools 里只勾选少数关键请求再导出，或精简 HAR 中无关 entries |
+| App 走的是 WebSocket / gRPC | 当前 QD 仅支持 HTTP(S)，不能直接重放 |
+
+---
+
+## 八、下一步
+
+抓到 `.har` 文件后，有两条路：
+
+1. **手动整理**：进入 QD 的「HAR 编辑器」 → **追加 HAR** 上传，逐条剔除噪声请求，再保存为模板。
+2. **AI 一键识别**（推荐）：直接上传后点击 **「AI 智能识别签到」** 按钮，让 AI 自动挑出签到接口。详见 [AI 转换签到模板教程](./ai-sign-template.md)。

--- a/web/handlers/base.py
+++ b/web/handlers/base.py
@@ -75,7 +75,7 @@ class _BaseHandler(tornado.web.RequestHandler):
             return ret
         user = umsgpack.unpackb(ret)
         try:
-            user['isadmin'] = 'admin' in user['role'] if isinstance(user, Union[Mapping, MutableMapping]) and user.get('role') else False
+            user['isadmin'] = 'admin' in user['role'] if isinstance(user, (Mapping, MutableMapping)) and user.get('role') else False
         except Exception as e:
             logger_web_handler.debug(e, exc_info=config.traceback_print)
             return None

--- a/web/handlers/har.py
+++ b/web/handlers/har.py
@@ -18,7 +18,7 @@ from jinja2.nodes import Filter, Name
 from tornado import httpclient
 
 import config
-from libs import json_typing, utils
+from libs import ai_client, json_typing, utils
 from libs.fetcher import Fetcher
 from libs.parse_url import parse_url
 from libs.safe_eval import safe_eval
@@ -521,10 +521,101 @@ class HARSave(BaseHandler):
         await self.finish({"id": id})
 
 
+class HARAIAnalyze(BaseHandler):
+    """根据用户提供的 HAR 抓包数据，调用 AI 提取签到请求并返回最小化 HAR。
+
+    请求体（JSON）：
+        {"har": <HAR JSON>, "hint": "可选的提示，例如 '签到接口'"}
+    响应体：
+        {"ok": true, "har": <精简 HAR>, "result": <AI 原始结果>}
+        或
+        {"ok": false, "error": "错误信息"}
+    """
+
+    @tornado.web.authenticated
+    async def post(self) -> None:
+        self.evil(+1)
+        client = ai_client.AIClient()
+        if not client.enabled:
+            self.set_status(503)
+            await self.finish(
+                {
+                    "ok": False,
+                    "error": "AI 功能未启用，请管理员设置环境变量 AI_API_KEY",
+                }
+            )
+            return
+
+        try:
+            payload = json.loads(self.request.body or b"{}")
+        except json.JSONDecodeError as e:
+            self.set_status(400)
+            await self.finish({"ok": False, "error": f"请求体不是合法 JSON: {e}"})
+            return
+
+        har = payload.get("har")
+        hint = payload.get("hint", "") or ""
+        if not isinstance(har, dict) or "log" not in har:
+            self.set_status(400)
+            await self.finish(
+                {"ok": False, "error": "har 字段缺失或格式不正确，需为 HAR JSON"}
+            )
+            return
+
+        try:
+            slim = ai_client.preprocess_har(har, config.ai_max_har_entries)
+            if not slim:
+                self.set_status(400)
+                await self.finish(
+                    {"ok": False, "error": "HAR 中未找到可分析的请求（可能均被过滤）"}
+                )
+                return
+            messages = ai_client.build_messages(slim, hint=hint)
+            content = await client.chat(messages, temperature=0.1)
+            result = ai_client.parse_ai_response(content)
+            har_out = ai_client.ai_result_to_har(result)
+        except ai_client.AIClientError as e:
+            logger_web_handler.warning("AI 分析失败: %s", e)
+            self.set_status(502)
+            await self.finish({"ok": False, "error": str(e)})
+            return
+        except Exception as e:
+            logger_web_handler.error(
+                "AI 分析异常: %s", e, exc_info=config.traceback_print
+            )
+            self.set_status(500)
+            await self.finish({"ok": False, "error": f"内部错误: {e}"})
+            return
+
+        await self.finish(
+            {
+                "ok": True,
+                "har": har_out,
+                "result": result,
+                "stats": {"input_entries": len(slim)},
+            }
+        )
+
+
+class HARAIStatus(BaseHandler):
+    """供前端查询 AI 功能是否可用。"""
+
+    async def get(self) -> None:
+        client = ai_client.AIClient()
+        await self.finish(
+            {
+                "enabled": client.enabled,
+                "model": client.model if client.enabled else "",
+            }
+        )
+
+
 handlers = [
     (r"/tpl/(\d+)/edit", HAREditor),
     (r"/tpl/(\d+)/save", HARSave),
     (r"/har/edit", HAREditor),
     (r"/har/save/?(\d+)?", HARSave),
     (r"/har/test", HARTest),
+    (r"/har/ai_analyze", HARAIAnalyze),
+    (r"/har/ai_status", HARAIStatus),
 ]

--- a/web/handlers/login.py
+++ b/web/handlers/login.py
@@ -204,11 +204,15 @@ class VerifyHandler(BaseHandler):
                 verified_code = base64.b64decode(code)
                 userid, verified_code = await self.db.user.decrypt(0, verified_code, sql_session=sql_session)
                 user = await self.db.user.get(userid, fields=('id', 'email', 'email_verified'), sql_session=sql_session)
-                assert user
-                assert not user['email_verified']
+                if not user:
+                    raise ValueError("User not found")
+                if user['email_verified']:
+                    raise ValueError("Email already verified")
                 email, time_time = await self.db.user.decrypt(userid, verified_code, sql_session=sql_session)
-                assert time.time() - time_time < 30 * 24 * 60 * 60
-                assert user['email'] == email
+                if time.time() - time_time >= 30 * 24 * 60 * 60:
+                    raise ValueError("Verification code expired")
+                if user['email'] != email:
+                    raise ValueError("Email mismatch")
 
                 await self.db.user.mod(userid,
                                        email_verified=True,
@@ -232,10 +236,13 @@ class PasswordResetHandler(BaseHandler):
             verified_code = base64.b64decode(code)
             userid, verified_code = await self.db.user.decrypt(0, verified_code)
             user = await self.db.user.get(userid, fields=('id', 'email', 'mtime'))
-            assert user
+            if not user:
+                raise ValueError("User not found")
             mtime, time_time = await self.db.user.decrypt(userid, verified_code)
-            assert mtime == user['mtime']
-            assert time.time() - time_time < 60 * 60
+            if mtime != user['mtime']:
+                raise ValueError("Token mismatch")
+            if time.time() - time_time >= 60 * 60:
+                raise ValueError("Reset link expired")
         except Exception as e:
             self.evil(+10)
             logger_web_handler.error('%r', e, exc_info=config.traceback_print)
@@ -277,10 +284,13 @@ class PasswordResetHandler(BaseHandler):
                     verified_code = base64.b64decode(code)
                     userid, verified_code = await self.db.user.decrypt(0, verified_code, sql_session=sql_session)
                     user = await self.db.user.get(userid, fields=('id', 'email', 'mtime', 'email_verified'), sql_session=sql_session)
-                    assert user
+                    if not user:
+                        raise ValueError("User not found")
                     mtime, time_time = await self.db.user.decrypt(userid, verified_code, sql_session=sql_session)
-                    assert mtime == user['mtime']
-                    assert time.time() - time_time < 60 * 60
+                    if mtime != user['mtime']:
+                        raise ValueError("Token mismatch")
+                    if time.time() - time_time >= 60 * 60:
+                        raise ValueError("Reset link expired")
                 except Exception as e:
                     self.evil(+10)
                     logger_web_handler.error('%r', e, exc_info=config.traceback_print)

--- a/web/static/har/ai_ctrl.js
+++ b/web/static/har/ai_ctrl.js
@@ -1,0 +1,92 @@
+// vim: set et sw=2 ts=2 sts=2 ff=unix fenc=utf8:
+// QD AI 智能识别签到 控制器
+(function() {
+  define(function(require, exports, module) {
+    var analysis = require('/static/har/analysis');
+    var utils = require('/static/components/utils');
+    return angular.module('ai_ctrl', []).controller('AIAnalyzeCtrl', function($scope, $rootScope, $http) {
+      $scope.ai_enabled = false;
+      $scope.ai_model = '';
+      $scope.hint = '';
+      $scope.error = '';
+      $scope.result = null;
+      $scope.result_text = '';
+
+      // 初始查询 AI 状态
+      $http.get('/har/ai_status').then(function(res) {
+        $scope.ai_enabled = !!(res.data && res.data.enabled);
+        $scope.ai_model = (res.data && res.data.model) || '';
+      }, function() {
+        $scope.ai_enabled = false;
+      });
+
+      $scope.ai_open = function() {
+        $scope.error = '';
+        $scope.result = null;
+        $scope.result_text = '';
+      };
+
+      // 把当前编辑器中的 har 转回标准 HAR 格式发给后端
+      function collect_har() {
+        // window.global_har 由 entry_list 维护，结构为 {filename, har: {log:{entries:[]}}, env}
+        var src = (window.global_har && window.global_har.har) ? window.global_har.har : null;
+        if (!src) return null;
+        return src;
+      }
+
+      $scope.run = function() {
+        var btn = $('#ai-analyze .btn-primary');
+        var har = collect_har();
+        if (!har) {
+          $scope.error = '当前没有 HAR 数据，请先上传或编辑 HAR 后再使用';
+          return;
+        }
+        $scope.error = '';
+        $scope.result = null;
+        $scope.result_text = '正在调用 AI 分析中，请稍候...';
+        btn.button('loading');
+        $http.post('/har/ai_analyze', {har: har, hint: $scope.hint || ''}).then(function(res) {
+          btn.button('reset');
+          if (!res.data || !res.data.ok) {
+            $scope.error = (res.data && res.data.error) || 'AI 分析失败';
+            $scope.result_text = '';
+            return;
+          }
+          $scope.result = res.data;
+          try {
+            $scope.result_text = JSON.stringify(res.data.result, null, 2);
+          } catch (e) {
+            $scope.result_text = String(res.data.result);
+          }
+        }, function(res) {
+          btn.button('reset');
+          var msg = '请求失败';
+          if (res && res.data && res.data.error) {
+            msg = res.data.error;
+          } else if (res && res.status) {
+            msg = 'HTTP ' + res.status;
+          }
+          $scope.error = msg;
+          $scope.result_text = '';
+        });
+      };
+
+      // 把 AI 给出的精简 HAR 应用到编辑器
+      $scope.apply = function() {
+        if (!$scope.result || !$scope.result.har) return;
+        var loaded = {
+          filename: ($scope.result.result && $scope.result.result.sitename) || 'AI 生成模板',
+          har: analysis.analyze($scope.result.har, {}),
+          upload: true
+        };
+        loaded.env = {};
+        var vars = analysis.find_variables(loaded.har) || [];
+        for (var i = 0; i < vars.length; i++) {
+          loaded.env[vars[i]] = '';
+        }
+        $rootScope.$emit('har-loaded', loaded);
+        angular.element('#ai-analyze').modal('hide');
+      };
+    });
+  });
+}).call(this);

--- a/web/static/har/editor.js
+++ b/web/static/har/editor.js
@@ -8,6 +8,7 @@
     var cookie_input, editor;
     require('/static/har/contenteditable');
     require('/static/har/upload_ctrl');
+    require('/static/har/ai_ctrl');
     require('/static/har/entry_list');
     require('/static/har/entry_editor');
     // contentedit-wrapper
@@ -82,7 +83,7 @@
       }
       return cookie_input != null ? cookie_input.scope().$parent.var.value = cookie_str : void 0;
     });
-    editor = angular.module('HAREditor', ['editablelist', 'upload_ctrl', 'entry_list', 'entry_editor']);
+    editor = angular.module('HAREditor', ['editablelist', 'upload_ctrl', 'ai_ctrl', 'entry_list', 'entry_editor']);
     return {
       init: function() {
         return angular.bootstrap(document.body, ['HAREditor']);

--- a/web/tpl/har/editor.html
+++ b/web/tpl/har/editor.html
@@ -148,6 +148,7 @@
 
       <div class="text-right">
         <button class="btn btn-default" data-toggle="modal" data-target="#upload-har" >追加HAR</button>
+        <button class="btn btn-default" data-toggle="modal" data-target="#ai-analyze" ng-click="ai_open()">AI 智能识别签到</button>
         <a id="download-har" target="_blank" class="btn btn-default" ng-click="download()">下载</a>
         <button class="btn btn-default" data-toggle="modal" data-target="#test-har" ng-click="pre_save()">测试</button>
         <button ng-if="!readonly" class="btn btn-primary" data-toggle="modal" data-target="#save-har" ng-click="pre_save()">保存</button>
@@ -267,6 +268,43 @@
 {% endraw %}
 {% include "har/entry_editor.html" %}
 {% raw %}
+
+  <!-- AI analyze modal -->
+  <div class="modal fade" id="ai-analyze" ng-controller="AIAnalyzeCtrl">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h4 class="modal-title">AI 智能识别签到请求</h4>
+        </div>
+        <div class="modal-body">
+          <div class="alert alert-warning" ng-if="!ai_enabled" role="alert">
+            AI 功能未启用：请管理员设置环境变量 <code>AI_API_KEY</code>（兼容 OpenAI 协议的服务）后重启 QD。
+          </div>
+          <div class="alert alert-info" ng-if="ai_enabled" role="alert">
+            当前模型：<strong>{{ ai_model }}</strong>。AI 将分析当前 HAR 中的请求，自动挑出签到接口并替换为最小可执行模板。建议在导入完整 HAR 后使用。
+          </div>
+          <div class="alert alert-danger" ng-if="error" role="alert">{{ error }}</div>
+          <div class="form-horizontal" role="form">
+            <div class="form-group">
+              <label class="col-sm-3 control-label">提示词（可选）</label>
+              <div class="col-sm-9">
+                <input ng-model="hint" placeholder="例：'每日签到' 或 '积分领取'，留空则交给 AI 自动判断">
+              </div>
+            </div>
+          </div>
+          <div ng-if="result" style="margin-top:10px">
+            <strong>AI 分析结果：</strong>
+            <pre style="max-height:240px;overflow:auto">{{ result_text }}</pre>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">取消</button>
+          <button type="button" class="btn btn-primary" data-loading-text="分析中..." ng-disabled="!ai_enabled" ng-click="run()">开始分析</button>
+          <button type="button" class="btn btn-success" ng-if="result" ng-click="apply()">应用为当前模板</button>
+        </div>
+      </div>
+    </div>
+  </div><!-- /.ai modal -->
 
   <!-- upload modal -->
   <div class="modal fade" id="upload-har" ng-controller="UploadCtrl">

--- a/worker.py
+++ b/worker.py
@@ -33,6 +33,7 @@ class BaseWorker:
         self.fetcher = Fetcher()
 
     async def clear_log(self, taskid, sql_session=None):
+        """清理单个 task 过期日志，使用批量删除。"""
         log_day = int(
             (await self.db.site.get(
                 1,
@@ -40,89 +41,155 @@ class BaseWorker:
                 sql_session=sql_session
             ))['logDay']
         )
-        for log in await self.db.tasklog.list(
+        cutoff = time.time() - log_day * 24 * 60 * 60
+        logs = await self.db.tasklog.list(
             taskid=taskid,
             fields=('id', 'ctime'),
-            sql_session=sql_session
-        ):
-            if (time.time() - log['ctime']) > (log_day * 24 * 60 * 60):
-                await self.db.tasklog.delete(
-                    log['id'],
-                    sql_session=sql_session
-                )
+            sql_session=sql_session,
+        )
+        expired_ids = [log['id'] for log in logs if log['ctime'] < cutoff]
+        if expired_ids:
+            await self.db.tasklog.delete(expired_ids, sql_session=sql_session)
 
     async def push_batch(self):
+        """定期推送任务日志。
+
+        优化：原实现存在 N+1 查询——每个 task 单独查 tasklog、每个 tplid 单独查 tpl。
+        现在按用户聚合后一次性批量查询，时间复杂度由 O(任务数 × 数据库往返) 降为
+        O(用户数 × 数据库往返)。
+        """
         try:
             async with self.db.transaction() as sql_session:
                 userlist = await self.db.user.list(
                     fields=('id', 'email', 'status', 'push_batch'),
                     sql_session=sql_session
                 )
+                if not userlist:
+                    return
                 pushtool = Pusher(self.db, sql_session=sql_session)
-                if userlist:
-                    for user in userlist:
-                        userid = user['id']
-                        push_batch = json.loads(user['push_batch'])
-                        if user['status'] == "Enable" and push_batch.get('sw') and isinstance(push_batch.get('time'), (float, int)) and time.time() >= push_batch['time']:  # noqa: E501
-                            logger_worker.debug(
-                                'User %d check push_batch task, waiting...',
-                                userid
-                            )
-                            title = "QD任务日志定期推送"
-                            delta = push_batch.get("delta", 86400)
-                            logtemp = time.strftime(
-                                "%Y-%m-%d %H:%M:%S", time.localtime(push_batch['time']))
-                            tmpdict = {}
-                            tmp = ""
-                            numlog = 0
-                            task_list = await self.db.task.list(
-                                userid=userid,
-                                fields=(
-                                    'id', 'tplid', 'note', 'disabled',
-                                    'last_success', 'last_failed', 'pushsw'
-                                ),
-                                sql_session=sql_session
-                            )
-                            for task in task_list:
-                                pushsw = json.loads(task['pushsw'])
-                                if pushsw["pushen"] and (task["disabled"] == 0 or (task.get("last_success", 0) and task.get("last_success", 0) >= push_batch['time'] - delta) or (task.get("last_failed", 0) and task.get("last_failed", 0) >= push_batch['time'] - delta)):
-                                    tmp0 = ""
-                                    tasklog_list = await self.db.tasklog.list(taskid=task["id"], fields=('success', 'ctime', 'msg'), sql_session=sql_session)
-                                    for log in tasklog_list:
-                                        if (push_batch['time'] - delta) < log['ctime'] <= push_batch['time']:
-                                            c_time = time.strftime(
-                                                "%Y-%m-%d %H:%M:%S", time.localtime(log['ctime']))
-                                            tmp0 += f"\\r\\n时间: {c_time}\\r\\n日志: {log['msg']}"
-                                            numlog += 1
-                                    tmplist = tmpdict.get(task['tplid'], [])
-                                    if tmp0:
-                                        tmplist.append(
-                                            f"\\r\\n-----任务{len(tmplist) + 1}-{task['note']}-----{tmp0}\\r\\n")
-                                    else:
-                                        tmplist.append(
-                                            f"\\r\\n-----任务{len(tmplist) + 1}-{task['note']}-----\\r\\n记录期间未执行定时任务，请检查任务! \\r\\n")
-                                    tmpdict[task['tplid']] = tmplist
-
-                            for tmpkey, tmpval in tmpdict.items():
-                                tmp_sitename = await self.db.tpl.get(tmpkey, fields=('sitename',), sql_session=sql_session)
-                                if tmp_sitename:
-                                    tmp = f"\\r\\n\\r\\n=====QD: {tmp_sitename['sitename']}====="
-                                    tmp += ''.join(tmpval)
-                                    logtemp += tmp
-                            push_batch["time"] = push_batch['time'] + delta
-                            if tmp and numlog:
-                                user_email = user.get('email', 'Unkown')
-                                logger_worker.debug(
-                                    "Start push batch log for user %s, email:%s", userid, user_email)
-                                await pushtool.pusher(userid, {"pushen": bool(push_batch.get("sw", False))}, 4080, title, logtemp)
-                                logger_worker.info(
-                                    "Complete push batch log for user %s, email:%s", userid, user_email)
-                            else:
-                                logger_worker.debug(
-                                    'User %s does not need to perform push_batch task, stop.', userid)
-                            await self.db.user.mod(userid, push_batch=json.dumps(push_batch), sql_session=sql_session)
+                now = time.time()
+                for user in userlist:
+                    push_batch = json.loads(user['push_batch'])
+                    if not (
+                        user['status'] == "Enable"
+                        and push_batch.get('sw')
+                        and isinstance(push_batch.get('time'), (float, int))
+                        and now >= push_batch['time']
+                    ):
+                        continue
+                    await self._push_batch_for_user(
+                        user, push_batch, pushtool, sql_session
+                    )
         except Exception as e:
             logger_worker.error('Push batch task failed: %s', e, exc_info=config.traceback_print)
+
+    async def _push_batch_for_user(self, user, push_batch, pushtool, sql_session):
+        userid = user['id']
+        logger_worker.debug('User %d check push_batch task, waiting...', userid)
+        title = "QD任务日志定期推送"
+        delta = push_batch.get("delta", 86400)
+        window_start = push_batch['time'] - delta
+        window_end = push_batch['time']
+        logtemp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(window_end))
+
+        task_list = await self.db.task.list(
+            userid=userid,
+            fields=(
+                'id', 'tplid', 'note', 'disabled',
+                'last_success', 'last_failed', 'pushsw'
+            ),
+            sql_session=sql_session,
+        )
+
+        active_tasks = []
+        for task in task_list:
+            pushsw = json.loads(task['pushsw'])
+            if not pushsw.get("pushen"):
+                continue
+            if (
+                task["disabled"] == 0
+                or (task.get("last_success", 0) and task['last_success'] >= window_start)
+                or (task.get("last_failed", 0) and task['last_failed'] >= window_start)
+            ):
+                active_tasks.append(task)
+
+        # 一次性批量查询，避免 N+1
+        task_ids = [t["id"] for t in active_tasks]
+        tpl_ids = list({t["tplid"] for t in active_tasks})
+        all_logs = (
+            await self.db.tasklog.list(
+                taskid=task_ids,
+                fields=('taskid', 'success', 'ctime', 'msg'),
+                sql_session=sql_session,
+                limit=None,
+            )
+            if task_ids
+            else []
+        )
+        tpl_map: Dict[int, dict] = {}
+        if tpl_ids:
+            tpl_rows = await self.db.tpl.list(
+                id=tpl_ids,
+                fields=('id', 'sitename'),
+                sql_session=sql_session,
+            )
+            tpl_map = {row['id']: row for row in tpl_rows}
+
+        logs_by_task: Dict[int, list] = {}
+        for log in all_logs:
+            if window_start < log['ctime'] <= window_end:
+                logs_by_task.setdefault(log['taskid'], []).append(log)
+
+        tmpdict: Dict[int, list] = {}
+        numlog = 0
+        for task in active_tasks:
+            tmp0 = ""
+            for log in logs_by_task.get(task["id"], []):
+                c_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(log['ctime']))
+                tmp0 += f"\\r\\n时间: {c_time}\\r\\n日志: {log['msg']}"
+                numlog += 1
+            tmplist = tmpdict.get(task['tplid'], [])
+            if tmp0:
+                tmplist.append(
+                    f"\\r\\n-----任务{len(tmplist) + 1}-{task['note']}-----{tmp0}\\r\\n"
+                )
+            else:
+                tmplist.append(
+                    f"\\r\\n-----任务{len(tmplist) + 1}-{task['note']}-----\\r\\n记录期间未执行定时任务，请检查任务! \\r\\n"
+                )
+            tmpdict[task['tplid']] = tmplist
+
+        tmp = ""
+        for tmpkey, tmpval in tmpdict.items():
+            tpl_row = tpl_map.get(tmpkey)
+            if tpl_row:
+                tmp = f"\\r\\n\\r\\n=====QD: {tpl_row['sitename']}====="
+                tmp += ''.join(tmpval)
+                logtemp += tmp
+
+        push_batch["time"] = push_batch['time'] + delta
+        if tmp and numlog:
+            user_email = user.get('email', 'Unkown')
+            logger_worker.debug(
+                "Start push batch log for user %s, email:%s", userid, user_email
+            )
+            await pushtool.pusher(
+                userid,
+                {"pushen": bool(push_batch.get("sw", False))},
+                4080,
+                title,
+                logtemp,
+            )
+            logger_worker.info(
+                "Complete push batch log for user %s, email:%s", userid, user_email
+            )
+        else:
+            logger_worker.debug(
+                'User %s does not need to perform push_batch task, stop.', userid
+            )
+        await self.db.user.mod(
+            userid, push_batch=json.dumps(push_batch), sql_session=sql_session
+        )
 
     @staticmethod
     def failed_count_to_time(last_failed_count, retry_count=config.task_max_retry_count, retry_interval=None, interval=None):

--- a/worker.py
+++ b/worker.py
@@ -164,7 +164,7 @@ class BaseWorker:
         Returns:
             next (float): fixed next timestamp
         """
-        date = datetime.datetime.utcfromtimestamp(next)
+        date = datetime.datetime.fromtimestamp(next, tz=datetime.timezone.utc)
         local_date = date - datetime.timedelta(minutes=gmt_offset)
         if local_date.hour < 2:
             next += 2 * 60 * 60


### PR DESCRIPTION
## 概述

本 PR 包含三组改动：**新增 AI 辅助签到模板生成功能**、**修复 worker 中存在的 N+1 性能问题**、**补充两份中文教程**。所有改动均后向兼容，不破坏现有 HAR 模板格式与执行逻辑。AI 功能默认关闭（环境变量为空），合并后对未配置用户零行为变化。

## 一、新增功能：AI 智能识别签到

在 HAR 编辑器右上角加入「AI 智能识别签到」按钮：用户上传 HAR 后一键调用大模型，从抓包数据中自动挑出真正的签到接口，输出最小化 HAR 直接覆盖到当前模板，省掉手动剔除噪声请求的环节。

- **后端**：`libs/ai_client.py`（兼容 OpenAI Chat Completions 协议）+ 两个端点：
  - `POST /har/ai_analyze` 接受 HAR 与可选提示词
  - `GET /har/ai_status` 供前端查询是否启用
- **前端**：`web/static/har/ai_ctrl.js` AngularJS 控制器 + 编辑器内弹窗
- **配置**：`AI_API_KEY` / `AI_BASE_URL` / `AI_MODEL` / `AI_TIMEOUT` / `AI_MAX_HAR_ENTRIES`
- **测试**：`tests/test_ai_client.py` 12 个用例覆盖噪声过滤 / Header 裁剪 / JSON 容错解析 / 结构转换
- 兼容 OpenAI / DeepSeek / 通义千问 / Moonshot / OpenRouter / 本地 Ollama
- 不引入任何新依赖：`aiohttp` 镜像中已自带

**隐私设计**：送给 AI 的 HAR 经预处理 —— 仅保留少量必要 header（Content-Type / Referer / Origin / Authorization / X-CSRF-Token），Cookie 只送名称不送值，请求体超过 500 字截断。

## 二、修复 worker N+1 查询

`worker.push_batch` 原实现在循环内对每个 task 单独 `SELECT tasklog`、对每个 tplid 单独 `SELECT tpl`，复杂度 `O(任务数 × DB 往返)`。重构为按用户聚合后一次性批量查询，复杂度降为 `O(用户数 × DB 往返)`。

附带改动：

- `worker.clear_log` 由逐条 `DELETE` 改为一次 `DELETE ... WHERE id IN (...)`
- `db.tasklog.list` / `db.task.list` / `db.tpl.list` 的 kwargs 现支持 `list/tuple/set` 自动转 SQL `IN`，向后兼容（标量仍走 `=`）

## 三、其他工程化改进

- **修复 `run.py` 已存在的 `IndentationError`**：第 61-62 行 `with open(version.json) as _f:` 块下一行未缩进
- **启动密钥告警**：若检测到 `COOKIE_SECRET` / `AES_KEY` 仍为默认 `binux` 或 `DOMAIN` 未设置，记录 WARNING（不阻止启动）

## 四、新增中文教程

- `web/docs/zh_CN/guide/har-capture.md` — 浏览器（Chrome / Edge / Firefox / Safari）、桌面工具（Fiddler / Charles / mitmproxy）、移动端（Android / iOS）抓 HAR 完整指南
- `web/docs/zh_CN/guide/ai-sign-template.md` — 启用 AI 功能 / 操作流程 / 提示词技巧 / Token 成本 / 安全合规

## 测试与兼容

- syntax 校验全部通过
- `python -m unittest tests.test_ai_client` 12/12 通过
- 未改动 `libs/fetcher.py` / `libs/safe_eval.py` / `libs/cookie_utils.py` 与三张核心表 schema，**老 HAR 模板执行路径完全不受影响**
