### PR TITLE
fix: 修复 async_scoped_session 内存泄漏

### DIFF
--- a/web/handlers/base.py
+++ b/web/handlers/base.py
@@ -16,6 +16,7 @@ from tornado.web import HTTPError
 
 import config
 from db import DB
+from db.basedb import async_session
 from libs import fetcher, utils
 from libs.log import Log
 
@@ -113,6 +114,15 @@ class BaseHandler(_BaseHandler):
             userid = user['id']
         if self.db.redis.is_evil(self.ip, userid):
             raise HTTPError(403)
+
+    async def _execute(self, transforms, *args, **kwargs):
+        # 修复 web handler session 泄漏:每个 HTTP 请求是一个 asyncio task,
+        # async_session() 用 current_task 作 scope,handler 结束时不清除则
+        # session 永久留在 registry 中,导致内存持续增长。
+        try:
+            return await super()._execute(transforms, *args, **kwargs)
+        finally:
+            await async_session.remove()
 
     def check_permission(self, obj, mode='r'):
         if not obj:

--- a/worker.py
+++ b/worker.py
@@ -18,6 +18,7 @@ from tornado.concurrent import Future
 
 import config
 from db import DB
+from db.basedb import async_session
 from libs.fetcher import Fetcher
 from libs.funcs import Cal, Pusher
 from libs.log import Log
@@ -173,6 +174,16 @@ class BaseWorker:
         return next
 
     async def do(self, task):
+        # 修复 async_scoped_session 内存泄漏: 每个 asyncio task 结束时
+        # 必须调用 async_session.remove() 清理 registry 中残留的 session,
+        # 否则 session 及其 identity map (expire_on_commit=False) 永不释放,
+        # 长期运行导致内存持续增长。
+        try:
+            return await self._do(task)
+        finally:
+            await async_session.remove()
+
+    async def _do(self, task):
         is_success = False
         should_push = 0
         userid = None
@@ -450,6 +461,8 @@ class BatchWorker(BaseWorker):
                 await self.push_batch()
         except Exception as e:
             logger_worker.exception(e)
+        finally:
+            await async_session.remove()
         return (success, failed)
 
 


### PR DESCRIPTION
## 问题

`db/basedb.py` 中的 `async_session` 由 `async_scoped_session` 创建，使用 `asyncio.current_task()` 作 scope。但原代码在 asyncio task 结束时从未调用 `async_session.remove()`，导致每个 task 对应的 session 及其 identity map（`expire_on_commit=False`）永久残留在 registry 中。

长期运行后内存持续增长（实测可累积到 1G+）：
- `BatchWorker.run()` 每 500ms 扫描一轮，即使无任务也会泄漏。
- `BaseHandler` 每个 HTTP 请求都泄漏一个 session。

## 修复

- `worker.py` `BaseWorker.do()`：原 `do()` 改名 `_do()`，外层用 `try/finally` 在 task 结束时调用 `async_session.remove()`。
- `worker.py` `BatchWorker.run()`：加 `finally` 清理每轮扫描结束后的 session。
- `web/handlers/base.py` `BaseHandler._execute()`：重写 Tornado 的 `_execute`，在请求结束时 `try/finally` 清理 session。

## 说明

- 本次仅提交泄漏修复，未改动 `BatchWorker` 的并发分批阈值（仍为 50）。
- 未引入任何行为/接口变更，`remove()` 在 registry 无 session 时是安全的 no-op。

🤖 Generated with [Claude Code](https://claude.com/claude-code)